### PR TITLE
Fix ln command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ On Mac:
 
 ```console
 docker buildx bake --file docker-bake.hcl darwin
-ln -sf ./bin/docker-compose ./bin/docker-mcpgateway ~/.docker/cli-plugins/
+ln -sf $(pwd)/bin/docker-compose $(pwd)/bin/docker-mcpgateway ~/.docker/cli-plugins/
 ```
 
 On Windows:


### PR DESCRIPTION
The command was producing symlinks that were literally pointing to `./bin/docker-mcpgateway`... which isn't going to resolve correctly.