### PR TITLE
Use qwen3:14B-Q6_K from the ai namespace

### DIFF
--- a/demos/adk/compose.yaml
+++ b/demos/adk/compose.yaml
@@ -20,7 +20,7 @@ services:
       type: model
       options:
         # pre-pull the model on Docker Model Runner
-        #model: olegselajev241/qwen3:14B-Q6_K
+        # model: ai/qwen3:14B-Q6_K
         model: ai/gemma3-qat:27B-Q4_K_M	
     environment:
       # only for gemma3

--- a/demos/agno/compose.yaml
+++ b/demos/agno/compose.yaml
@@ -22,7 +22,7 @@ services:
     provider:
       type: model
       options:
-        model: olegselajev241/qwen3:14B-Q6_K
+        model: ai/qwen3:14B-Q6_K
     environment:
       - LLAMA_ARGS=--ctx-size 8000 --jinja -ngl 100
 

--- a/demos/langgraph/compose.yaml
+++ b/demos/langgraph/compose.yaml
@@ -55,7 +55,7 @@ services:
     provider:
       type: model
       options:
-        model: olegselajev241/qwen3:14B-Q6_K
+        model: ai/qwen3:14B-Q6_K
 
 secrets:
   database_url:


### PR DESCRIPTION
Small update to use the qwen model from the official namespace instead of a personal namespace