### PR TITLE
Use a small gemma model by default

### DIFF
--- a/a2a/README.md
+++ b/a2a/README.md
@@ -33,6 +33,12 @@ docker compose up --build
 No configuration needed — everything runs from the container. Open `http://localhost:8080` in your browser to and select `AgentKit` in the selector at the top right, then chat with
 the agents.
 
+Using the Docker Offload with GPU support, you can run the same demo with a larger model that offloads to GPU:
+
+```sh
+docker compose -f compose.yml -f compose.offload.yml up --build
+```
+
 
 # ❓ What Can It Do?
 

--- a/a2a/compose.offload.yml
+++ b/a2a/compose.offload.yml
@@ -1,0 +1,10 @@
+services:
+  model_runner:
+    provider:
+      type: model
+      options:
+        # pre-pull the model on Docker Model Runner
+        model: ai/gemma3-qat:27B-Q4_K_M	
+        # context-size: 10000 # 18.6 GB VRAM
+        # context-size: 80000 # 28.37 GB VRAM
+        context-size: 131000 # 35.5 GB VRAM

--- a/a2a/compose.yml
+++ b/a2a/compose.yml
@@ -38,10 +38,9 @@ services:
       type: model
       options:
         # pre-pull the model on Docker Model Runner
-        model: ai/gemma3-qat:27B-Q4_K_M	
-        context-size: 41000 # 23 GB VRAM
-        # context-size: 80000 # 28 GB VRAM
-        # context-size: 131000 # 36 GB VRAM
+        model: ai/gemma3:4B-Q4_0
+        context-size: 10000 # 3.5 GB VRAM
+        # context-size: 131000 # 7.6 GB VRAM
 
   mcp-gateway:
     image: docker/agents_gateway:v2


### PR DESCRIPTION
Add a bigger gemma model with a compose.offload.yml to override the default compose when using Docker Offload