### PR TITLE
modify auditor-agent-a2a models to target gemma3 model

### DIFF
--- a/a2a/compose.yaml
+++ b/a2a/compose.yaml
@@ -12,7 +12,7 @@ services:
       - critic-agent-a2a
       - reviser-agent-a2a
     models:
-       agents:
+      gemma3:
          endpoint_var: MODEL_RUNNER_URL
          model_var: MODEL_RUNNER_MODEL
 


### PR DESCRIPTION
Currently the `auditor-agent-a2a` references a `agents` model which isn't part of the current Compose model