### PR TITLE
define the qwen3-large models close to the offload compose override file

### DIFF
--- a/agno/compose.offload.yaml
+++ b/agno/compose.offload.yaml
@@ -5,3 +5,10 @@ services:
       qwen3-large:
         endpoint_var: MODEL_RUNNER_URL
         model_var: MODEL_RUNNER_MODEL
+
+models:
+  qwen3-large:
+    model: ai/qwen3:30B-A3B-Q4_K_M # 17.28 GB
+    context_size: 15000 # 20 GB VRAM
+    # increase context size to handle larger results
+    # context_size: 41000 # 24 GB VRAM

--- a/agno/compose.yaml
+++ b/agno/compose.yaml
@@ -55,11 +55,13 @@ models:
     context_size: 15000 # 15 GB VRAM
     # increase context size to handle larger results
     # context_size: 41000 # 21 GB VRAM
-  qwen3-large:
-    model: ai/qwen3:30B-A3B-Q4_K_M # 17.28 GB
-    context_size: 15000 # 20 GB VRAM
-    # increase context size to handle larger results
-    # context_size: 41000 # 24 GB VRAM
+
+  # The qwen3-large model is defined in compose.offload.yaml
+  # because it requires more resources and is intended to run with Docker Offload.
+  # A recommended practice with Docker Compose is to isolate specialized configurations
+  # in override files. These files modify the base setup when applied,
+  # in our case:
+  # docker compose -f compose.yaml -f compose.offload.yaml up --build
 
 # mount the secrets file for MCP servers
 secrets:


### PR DESCRIPTION
According to best practices for Compose configuration, the `qwen3-large` model definition should ideally be declared near the service that uses it, typically within the `compose.offload.yaml` file.

That said, feel free to close the PR if you've chosen this configuration for educational purposes, for example to demonstrate how the same model type can be defined with different sizes or capabilities.