### PR TITLE
rename models to qwen3 to avoid confusion with the services named also agent

### DIFF
--- a/crew-ai/compose.yaml
+++ b/crew-ai/compose.yaml
@@ -8,7 +8,7 @@ services:
     depends_on:
       - mcp-gateway
     models:
-      agent:
+      qwen3:
         endpoint_var: MODEL_RUNNER_URL
         model_var: MODEL_RUNNER_MODEL
 
@@ -23,7 +23,7 @@ services:
       - --tools=search,fetch_content
 
 models:
-  agent:
+  qwen3:
     model: ai/qwen3
     context_size: 8192
     runtime_flags:

--- a/langgraph/compose.yaml
+++ b/langgraph/compose.yaml
@@ -34,7 +34,7 @@ services:
     depends_on:
       - database
     models:
-      agent:
+      qwen3:
         endpoint_var: MODEL_RUNNER_URL
         model_var: MODEL_RUNNER_MODEL
 
@@ -52,7 +52,7 @@ services:
       - database_url
 
 models:
-  agent:
+  qwen3:
     model: ai/qwen3:14B-Q6_K
 
 secrets:


### PR DESCRIPTION
Renaming to avoid confusion when reading the compose files between the services and the models used