### PR TITLE
feat: add OpenAI support to all single-model demos

### DIFF
--- a/a2a/.env.example
+++ b/a2a/.env.example
@@ -1,1 +1,0 @@
-OPENAI_API_KEY=<your-api-key>

--- a/a2a/.gitignore
+++ b/a2a/.gitignore
@@ -1,4 +1,4 @@
-/.env
+/secret.*
 /.vscode
 /.venv
 /.mypy_cache

--- a/a2a/Dockerfile
+++ b/a2a/Dockerfile
@@ -14,17 +14,19 @@ RUN python -m compileall -q .
 ENV AGENT_CONFIG=/app/agent.yaml
 
 COPY <<EOF ./entrypoint.sh
-#!/bin/bash
-set -e
-
 #!/bin/sh
 set -e
+
+if test -f /run/secrets/openai-api-key; then
+    export OPENAI_API_KEY=$(cat /run/secrets/openai-api-key)
+fi
+
 if test -n "\${OPENAI_API_KEY}"; then
-    echo "OPENAI_API_KEY is set, using OpenAI with \${MODEL_NAME}"
+    echo "Using OpenAI with \${MODEL_NAME}"
     export LLM_AGENT_MODEL_PROVIDER=openai
     export LLM_AGENT_MODEL_NAME=\${OPENAI_MODEL_NAME}
 else
-    echo "OPENAI_API_KEY is not set, using Docker Model Runner with \${MODEL_RUNNER_MODEL}"
+    echo "Using Docker Model Runner with \${MODEL_RUNNER_MODEL}"
     export LLM_AGENT_MODEL_PROVIDER=docker
     export LLM_AGENT_MODEL_NAME=\${MODEL_RUNNER_MODEL}
 fi

--- a/a2a/README.md
+++ b/a2a/README.md
@@ -45,23 +45,17 @@ By default, this project uses [Docker Model Runner] to handle LLM inference loca
 
 If you’d prefer to use OpenAI instead:
 
-1. Copy the example environment file:
-
-```sh
-cp .env.example .env
-```
-
-2. Edit `.env` and set your OpenAI API key:
+1. Create a `secret.openai-api-key` file with your OpenAI API key:
 
 ```
-OPENAI_API_KEY=sk-...
+sk-...
 ```
 
-3. Restart the project:
+2. Restart the project with the OpenAI configuration:
 
 ```
 docker compose down -v
-docker compose up
+docker compose -f compose.yaml -f compose.openai.yaml up
 ```
 
 # ❓ What Can It Do?
@@ -150,3 +144,4 @@ docker compose down -v
 [DuckDuckGo]: https://duckduckgo.com
 [Docker Compose]: https://github.com/docker/compose
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Model Runner]: https://docs.docker.com/ai/model-runner/

--- a/a2a/compose.openai.yaml
+++ b/a2a/compose.openai.yaml
@@ -1,0 +1,21 @@
+
+services:
+  auditor-agent-a2a:
+    environment:
+      - OPENAI_MODEL_NAME=o3
+    secrets:
+      - openai-api-key
+  critic-agent-a2a:
+    environment:
+      - OPENAI_MODEL_NAME=o3
+    secrets:
+      - openai-api-key
+  reviser-agent-a2a:
+    environment:
+      - OPENAI_MODEL_NAME=o3
+    secrets:
+      - openai-api-key
+
+secrets:
+  openai-api-key:
+    file: secret.openai-api-key

--- a/a2a/compose.yaml
+++ b/a2a/compose.yaml
@@ -8,8 +8,6 @@ services:
     environment:
       - CRITIC_AGENT_URL=http://critic-agent-a2a:8001
       - REVISER_AGENT_URL=http://reviser-agent-a2a:8001
-      - OPENAI_API_KEY=$OPENAI_API_KEY
-      - OPENAI_MODEL_NAME=o3
     depends_on:
       - critic-agent-a2a
       - reviser-agent-a2a
@@ -23,8 +21,6 @@ services:
       target: critic-agent
     environment:
       - MCPGATEWAY_ENDPOINT=http://mcp-gateway:8811/sse
-      - OPENAI_API_KEY=$OPENAI_API_KEY
-      - OPENAI_MODEL_NAME=o3
     depends_on:
       - mcp-gateway
     models:
@@ -38,8 +34,6 @@ services:
       target: reviser-agent
     environment:
       - MCPGATEWAY_ENDPOINT=http://mcp-gateway:8811/sse
-      - OPENAI_API_KEY=$OPENAI_API_KEY
-      - OPENAI_MODEL_NAME=o3
     depends_on:
       - mcp-gateway
     models:

--- a/adk/.env.example
+++ b/adk/.env.example
@@ -1,1 +1,0 @@
-OPENAI_API_KEY=<your-api-key>

--- a/adk/.gitignore
+++ b/adk/.gitignore
@@ -1,4 +1,4 @@
-/.env
+/secret.*
 /.vscode
 /.venv
 /.mypy_cache

--- a/adk/Dockerfile
+++ b/adk/Dockerfile
@@ -16,11 +16,15 @@ RUN python -m compileall -q .
 COPY <<EOF /entrypoint.sh
 #!/bin/sh
 set -e
+
+if test -f /run/secrets/openai-api-key; then
+    export OPENAI_API_KEY=$(cat /run/secrets/openai-api-key)
+fi
+
 if test -n "\${OPENAI_API_KEY}"; then
-    echo "OPENAI_API_KEY is set, using OpenAI with \${MODEL_NAME}"
-    export OPENAI_MODEL_NAME=\${MODEL_NAME}
+    echo "Using OpenAI with \${OPENAI_MODEL_NAME}"
 else
-    echo "OPENAI_API_KEY is not set, using Docker Model Runner with \${MODEL_RUNNER_MODEL}"
+    echo "Using Docker Model Runner with \${MODEL_RUNNER_MODEL}"
     export OPENAI_BASE_URL=\${MODEL_RUNNER_URL}
     export OPENAI_MODEL_NAME=openai/\${MODEL_RUNNER_MODEL}
     export OPENAI_API_KEY=cannot_be_empty

--- a/adk/README.md
+++ b/adk/README.md
@@ -45,23 +45,17 @@ By default, this project uses [Docker Model Runner] to handle LLM inference loca
 
 If you’d prefer to use OpenAI instead:
 
-1. Copy the example environment file:
-
-```sh
-cp .env.example .env
-```
-
-2. Edit `.env` and set your OpenAI API key:
+1. Create a `secret.openai-api-key` file with your OpenAI API key:
 
 ```
-OPENAI_API_KEY=sk-...
+sk-...
 ```
 
-3. Restart the project:
+2. Restart the project with the OpenAI configuration:
 
 ```
 docker compose down -v
-docker compose up
+docker compose -f compose.yaml -f compose.openai.yaml up
 ```
 
 # ❓ What Can It Do?
@@ -151,3 +145,4 @@ docker compose down -v
 [DuckDuckGo]: https://duckduckgo.com
 [Docker Compose]: https://github.com/docker/compose
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Model Runner]: https://docs.docker.com/ai/model-runner/

--- a/adk/compose.openai.yaml
+++ b/adk/compose.openai.yaml
@@ -1,0 +1,10 @@
+services:
+  adk:
+    environment:
+      - OPENAI_MODEL_NAME=o3
+    secrets:
+      - openai-api-key
+
+secrets:
+  openai-api-key:
+    file: secret.openai-api-key

--- a/adk/compose.yaml
+++ b/adk/compose.yaml
@@ -6,8 +6,6 @@ services:
       # expose port for web interface
       - "8080:8080"
     environment:
-      - OPENAI_API_KEY=$OPENAI_API_KEY
-      - MODEL_NAME=o3
       # point adk at the MCP gateway
       - MCPGATEWAY_ENDPOINT=http://mcp-gateway:8811/sse
     depends_on:

--- a/crew-ai/.env.example
+++ b/crew-ai/.env.example
@@ -1,1 +1,0 @@
-OPENAI_API_KEY=<your-api-key>

--- a/crew-ai/.gitignore
+++ b/crew-ai/.gitignore
@@ -1,4 +1,4 @@
-/.env
+/secret.*
 /.vscode
 /.venv
 /.mypy_cache

--- a/crew-ai/Dockerfile
+++ b/crew-ai/Dockerfile
@@ -10,13 +10,17 @@ COPY . .
 RUN poetry install
 COPY <<EOF /entrypoint.sh
 #!/bin/sh
+
+if test -f /run/secrets/openai-api-key; then
+    export OPENAI_API_KEY=$(cat /run/secrets/openai-api-key)
+fi
+
 if test -n "\${OPENAI_API_KEY}"; then
-    echo "OPENAI_API_KEY is set, using OpenAI with \${MODEL_NAME}"
-    export OPENAI_MODEL_NAME=\${MODEL_NAME}
+    echo "Using OpenAI with \${OPENAI_MODEL_NAME}"
 else
-    echo "OPENAI_API_KEY is not set, using Docker Model Runner with \${MODEL_RUNNER_MODEL}"
+    echo "Using Docker Model Runner with \${MODEL_RUNNER_MODEL}"
     export OPENAI_BASE_URL=\${MODEL_RUNNER_URL}
-    export OPENAI_MODEL_NAME=\${MODEL_RUNNER_MODEL}
+    export OPENAI_MODEL_NAME=openai/\${MODEL_RUNNER_MODEL}
     export OPENAI_API_KEY=cannot_be_empty
 fi
 exec poetry run marketing_posts

--- a/crew-ai/README.md
+++ b/crew-ai/README.md
@@ -35,23 +35,17 @@ By default, this project uses [Docker Model Runner] to handle LLM inference loca
 
 If you’d prefer to use OpenAI instead:
 
-1. Copy the example environment file:
-
-```sh
-cp .env.example .env
-```
-
-2. Edit `.env` and set your OpenAI API key:
+1. Create a `secret.openai-api-key` file with your OpenAI API key:
 
 ```
-OPENAI_API_KEY=sk-...
+sk-...
 ```
 
-3. Restart the project:
+2. Restart the project with the OpenAI configuration:
 
 ```
 docker compose down -v
-docker compose up
+docker compose -f compose.yaml -f compose.openai.yaml up
 ```
 
 ## ❓ What Can It Do?
@@ -166,3 +160,4 @@ docker compose down -v
 [DuckDuckGo]: https://duckduckgo.com
 [Docker Compose]: https://github.com/docker/compose
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Model Runner]: https://docs.docker.com/ai/model-runner/

--- a/crew-ai/compose.openai.yaml
+++ b/crew-ai/compose.openai.yaml
@@ -1,0 +1,10 @@
+services:
+  agents:
+    environment:
+      - OPENAI_MODEL_NAME=gpt-4.1-mini
+    secrets:
+      - openai-api-key
+
+secrets:
+  openai-api-key:
+    file: secret.openai-api-key

--- a/crew-ai/compose.yaml
+++ b/crew-ai/compose.yaml
@@ -3,8 +3,6 @@ services:
     build:
         context: .
     environment:
-      - OPENAI_API_KEY=$OPENAI_API_KEY
-      - MODEL_NAME=gpt-4.1-mini
       - MCP_SERVER_URL=http://mcp-gateway:8811/sse
     restart: no
     depends_on:

--- a/langgraph/.env.example
+++ b/langgraph/.env.example
@@ -1,1 +1,0 @@
-OPENAI_API_KEY=<your-api-key>

--- a/langgraph/.gitignore
+++ b/langgraph/.gitignore
@@ -1,4 +1,4 @@
-/.env
+/secret.*
 /.vscode
 /.venv
 /.mypy_cache

--- a/langgraph/Dockerfile
+++ b/langgraph/Dockerfile
@@ -21,10 +21,16 @@ RUN python -m compileall -q .
 COPY <<EOF /entrypoint.sh
 #!/bin/sh
 set -e
+
+if test -f /run/secrets/openai-api-key; then
+    export OPENAI_API_KEY=$(cat /run/secrets/openai-api-key)
+fi
+
 if test -n "\${OPENAI_API_KEY}"; then
-    echo "OPENAI_API_KEY is set, using OpenAI with \${MODEL_NAME}"
+    echo "Using OpenAI with \${OPENAI_MODEL_NAME}"
+    export MODEL_NAME=\${OPENAI_MODEL_NAME}
 else
-    echo "OPENAI_API_KEY is not set, using Docker Model Runner with \${MODEL_RUNNER_MODEL}"
+    echo "Using Docker Model Runner with \${MODEL_RUNNER_MODEL}"
     export OPENAI_BASE_URL=\${MODEL_RUNNER_URL}
     export MODEL_NAME=\${MODEL_RUNNER_MODEL}
     export OPENAI_API_KEY=cannot_be_empty

--- a/langgraph/README.md
+++ b/langgraph/README.md
@@ -34,23 +34,17 @@ By default, this project uses [Docker Model Runner] to handle LLM inference loca
 
 If you’d prefer to use OpenAI instead:
 
-1. Copy the example environment file:
-
-```sh
-cp .env.example .env
-```
-
-2. Edit `.env` and set your OpenAI API key:
+1. Create a `secret.openai-api-key` file with your OpenAI API key:
 
 ```
-OPENAI_API_KEY=sk-...
+sk-...
 ```
 
-3. Restart the project:
+2. Restart the project with the OpenAI configuration:
 
 ```
 docker compose down -v
-docker compose up
+docker compose -f compose.yaml -f compose.openai.yaml up
 ```
 
 # ❓ What Can It Do?
@@ -123,3 +117,4 @@ docker compose down -v
 [PostgreSQL]: https://postgresql.org
 [Docker Compose]: https://github.com/docker/compose
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Model Runner]: https://docs.docker.com/ai/model-runner/

--- a/langgraph/compose.openai.yaml
+++ b/langgraph/compose.openai.yaml
@@ -1,0 +1,10 @@
+services:
+  agent:
+    environment:
+      - OPENAI_MODEL_NAME=gpt-4.1-mini
+    secrets:
+      - openai-api-key
+
+secrets:
+  openai-api-key:
+    file: secret.openai-api-key

--- a/langgraph/compose.yaml
+++ b/langgraph/compose.yaml
@@ -28,8 +28,6 @@ services:
     build:
       target: agent
     environment:
-      - OPENAI_API_KEY=$OPENAI_API_KEY
-      - MODEL_NAME=gpt-4.1-mini
       - MCP_SERVER_URL=http://mcp-gateway:8811/sse
       - DATABASE_DIALECT=PostgreSQL
       - QUESTION="Which sales agent made the most in sales in 2009?"
@@ -46,17 +44,17 @@ services:
     use_api_socket: true
     command:
       - --transport=sse
-      - --secrets=/run/secrets/database_url
+      - --secrets=/run/secrets/database-url
       # add any MCP servers you want to use
       - --servers=postgres
       - --tools=query
     secrets:
-      - database_url
+      - database-url
 
 models:
   qwen3:
     model: ai/qwen3:14B-Q6_K
 
 secrets:
-  database_url:
+  database-url:
     file: ./postgres_url

--- a/spring-ai/.env.example
+++ b/spring-ai/.env.example
@@ -1,1 +1,0 @@
-OPENAI_API_KEY=<your-api-key>

--- a/spring-ai/.gitignore
+++ b/spring-ai/.gitignore
@@ -1,1 +1,1 @@
-/.env
+/secret.*

--- a/spring-ai/Dockerfile
+++ b/spring-ai/Dockerfile
@@ -25,13 +25,17 @@ ENV SPRING_PROFILES_ACTIVE=prod
 COPY <<EOF entrypoint.sh
 #!/bin/sh
 
+if test -f /run/secrets/openai-api-key; then
+    export OPENAI_API_KEY=$(cat /run/secrets/openai-api-key)
+fi
+
 if test -n "\${OPENAI_API_KEY}"; then
-    echo "OPENAI_API_KEY is set, using OpenAI with \${MODEL_NAME}"
+    echo "Using OpenAI with \${MODEL_NAME}"
     export OPENAI_BASE_URL=https://api.openai.com/v1
 else
-    echo "OPENAI_API_KEY is not set, using Docker Model Runner with \${MODEL_RUNNER_MODEL}"
+    echo "Using Docker Model Runner with \${MODEL_RUNNER_MODEL}"
     export OPENAI_BASE_URL=\${MODEL_RUNNER_URL}
-    export MODEL_NAME=\${MODEL_RUNNER_MODEL}
+    export OPENAI_MODEL_NAME=\${MODEL_RUNNER_MODEL}
     export OPENAI_API_KEY=cannot_be_empty
 fi
 

--- a/spring-ai/README.md
+++ b/spring-ai/README.md
@@ -33,23 +33,17 @@ By default, this project uses [Docker Model Runner] to handle LLM inference loca
 
 If you’d prefer to use OpenAI instead:
 
-1. Copy the example environment file:
-
-```sh
-cp .env.example .env
-```
-
-2. Edit `.env` and set your OpenAI API key:
+1. Create a `secret.openai-api-key` file with your OpenAI API key:
 
 ```
-OPENAI_API_KEY=sk-...
+sk-...
 ```
 
-3. Restart the project:
+2. Restart the project with the OpenAI configuration:
 
 ```
 docker compose down -v
-docker compose up
+docker compose -f compose.yaml -f compose.openai.yaml up
 ```
 
 # ❓ What Can It Do?
@@ -108,3 +102,4 @@ flowchart TD
 [Spring AI]: https://github.com/spring-projects/spring-ai
 [Docker Compose]: https://docs.docker.com/compose/
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Model Runner]: https://docs.docker.com/ai/model-runner/

--- a/spring-ai/compose.openai.yaml
+++ b/spring-ai/compose.openai.yaml
@@ -1,0 +1,10 @@
+services:
+  app:
+    environment:
+      - OPENAI_MODEL_NAME=gpt-4.1
+    secrets:
+      - openai-api-key
+
+secrets:
+  openai-api-key:
+    file: secret.openai-api-key

--- a/spring-ai/compose.yaml
+++ b/spring-ai/compose.yaml
@@ -5,8 +5,6 @@ services:
     ports:
       - 8080:8080
     environment:
-      - OPENAI_API_KEY=$OPENAI_API_KEY
-      - MODEL_NAME=gpt-4.1
       - SPRING_PROFILES_ACTIVE=prod
       - SERVER_PORT=8080
       - MCP_GATEWAY_URL=http://mcp-gateway:8811

--- a/spring-ai/src/main/resources/application.properties
+++ b/spring-ai/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.main.web-application-type=none
 logging.level.spring.ai.openai=DEBUG
 spring.ai.openai.base-url=${OPENAI_BASE_URL}
 spring.ai.openai.api-key=${OPENAI_API_KEY}
-spring.ai.openai.chat.options.model=${MODEL_NAME:ai/gemma3-qat}
+spring.ai.openai.chat.options.model=${OPENAI_MODEL_NAME:ai/gemma3-qat}
 
 spring.ai.mcp.client.sse.connections.gateway.url=${MCP_GATEWAY_URL:http://localhost:8811}
 


### PR DESCRIPTION
- Updated a2a, adk, crewai, langgraph and spring-ai
- Use an additional `compose.openai.yaml` to enable OpenAI
- Print the selected model during the container startup
- Update all README to include the available options for inference
