### PR TITLE
adk: update Dockerfile for Windows compatiblity

### DIFF
--- a/adk/Dockerfile
+++ b/adk/Dockerfile
@@ -32,7 +32,7 @@ else
 fi
 exec adk web --host 0.0.0.0 --port 8080 --log_level DEBUG
 EOF
-RUN chmod +x /entrypoint.sh
+RUN chmod +x /entrypoint.sh && sed -i 's/\r$//' /entrypoint.sh
 
 # Create non-root user
 RUN useradd --create-home --shell /bin/bash app \


### PR DESCRIPTION
Running the demo on a Windows machine gives the error `exec /entrypoint.sh: no such file or directory` because the `entrypoint.sh` is created in the Dockerfile and Windows uses different line endings.

Not sure what the best practice is, but this fixes for me by changing the line endings after the file is created. I assume this doesn't affect Mac/Linux, but I can't test it.