### PR TITLE
use correct URL for agno github URL

### DIFF
--- a/agno/README.md
+++ b/agno/README.md
@@ -149,7 +149,7 @@ docker compose down -v
 - [GitHub MCP Server] - Model Context Protocol integration
 - [Docker Compose] - Container orchestration
 
-[Agno]: https://github.com/agno-ai/agno
+[Agno]: https://github.com/agno-agi/agno
 [GitHub MCP Server]: https://github.com/modelcontextprotocol/servers
 [Docker Compose]: https://github.com/docker/compose
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/


### PR DESCRIPTION
Update the URL used in the README to point to the Agno GitHub