### PR TITLE
Fix: Correct Agno project classification from Single Agent to Multi-Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ docker compose -f compose.yaml -f compose.openai.yaml up
 
 | Demo | Agent System | Models | MCPs | project | compose |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| [Agno](https://github.com/agno-agi/agno) agent that summarizes GitHub issues | Single Agent | qwen3(local) | github-official | [./agno](./agno) | [compose.yaml](./agno/compose.yaml) |
+| [Agno](https://github.com/agno-agi/agno) agent that summarizes GitHub issues | Multi-Agent | qwen3(local) | github-official | [./agno](./agno) | [compose.yaml](./agno/compose.yaml) |
 | [Vercel AI-SDK](https://github.com/vercel/ai) Chat-UI for mixing MCPs and Model | Single Agent | llama3.2(local), qwen3(local) | wikipedia-mcp, brave, resend(email) | [./vercel](./vercel) | [compose.yaml](https://github.com/slimslenderslacks/scira-mcp-chat/blob/main/compose.yaml) |
 | [CrewAI](https://github.com/crewAIInc/crewAI) Marketing Strategy Agent | Multi-Agent | qwen3(local) | duckduckgo | [./crew-ai](./crew-ai) | [compose.yaml](https://github.com/docker/compose-agents-demo/blob/main/crew-ai/compose.yaml) |
 | [ADK](https://github.com/google/adk-python) Multi-Agent Fact Checker | Multi-Agent | gemma3-qat(local) | duckduckgo | [./adk](./adk) | [compose.yaml](./adk/compose.yaml) |


### PR DESCRIPTION
This PR fixes incorrect categorization of the Agno GitHub Issues Summarizer in the demo examples table.
