### PR TITLE
chore(ci): lint markdown files

### DIFF
--- a/.github/workflows/markdownlint.yaml
+++ b/.github/workflows/markdownlint.yaml
@@ -1,0 +1,30 @@
+# .github/workflows/markdownlint.yml
+name: Lint
+
+on:
+  push:
+    paths:
+      - '**/*.md'
+      - '.github/workflows/markdownlint.yaml'
+    branches:
+      - main
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.github/workflows/markdownlint.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  lint-markdown:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Install Task
+        uses: arduino/setup-task@8b35f53e4d5a51bf691c94c71f2c7222483206cb
+
+      - name: Lint Markdown Files
+        run: task lint:markdown

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,7 @@
+# Define glob expressions to use (only valid at root)
+globs:
+  - "**/*.md"
+ignores:
+  - "**/.venv/**"
+# Show found files on stdout (only valid at root)
+showFound: true

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,21 @@
+# .markdownlint.yaml
+
+# MD001: Heading levels should only increment by one level at a time
+MD001: false
+
+# MD004: Unordered list style - allow different styles in sublists
+MD004:
+  style: sublist
+
+# MD013: Line length
+MD013:
+  line_length: 120
+  code_blocks: false
+  tables: false
+
+# MD025: Multiple top-level headings allowed
+MD025: false
+
+# MD033: Inline HTML
+MD033:
+  allowed_elements: [p, img]

--- a/README.md
+++ b/README.md
@@ -2,43 +2,50 @@
 
 ## Prerequisites
 
-+ **[Docker Desktop](https://www.docker.com/products/docker-desktop/) 4.43.0+ or [Docker Engine](https://docs.docker.com/engine/)** installed
-+ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you don't have a GPU, you can alternatively use [**Docker Offload**](https://www.docker.com/products/docker-offload).
-+ If you're using Docker Engine on Linux or Docker Desktop on Windows, ensure that the [Docker Model Runner requirements](https://docs.docker.com/ai/model-runner/) are met (specifically that GPU support is enabled) and the necessary drivers are installed
-+ If you're using Docker Engine on Linux, ensure you have Compose 2.38.1 or later installed
++ **[Docker Desktop] 4.43.0+ or [Docker Engine]** installed.
++ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you
+  don't have a GPU, you can alternatively use **[Docker Offload]**.
++ If you're using [Docker Engine] on Linux or [Docker Desktop] on Windows, ensure that the
+  [Docker Model Runner requirements] are met (specifically that GPU
+  support is enabled) and the necessary drivers are installed.
++ If you're using Docker Engine on Linux, ensure you have [Docker Compose] 2.38.1 or later installed.
 
 ## Demos
 
-Each of these demos is self-contained and can be run either locally or using a cloud context. They are all configured using two steps.
+Each of these demos is self-contained and can be run either locally or using a cloud context. They
+are all configured using two steps.
 
 1. change directory to the root of the demo project
-1. create a `.mcp.env` file from the `mcp.env.example` file (if it exists, otherwise the demo doesn't need any secrets) and supply the required MCP tokens
-1. run `docker compose up --build`
+2. create a `.mcp.env` file from the `mcp.env.example` file (if it exists, otherwise the demo
+   doesn't need any secrets) and supply the required MCP tokens
+3. run `docker compose up --build`
 
 ### Using OpenAI models
 
 The demos support using OpenAI models instead of running models locally with Docker Model Runner. To use OpenAI:
+
 1. Create a `secret.openai-api-key` file with your OpenAI API key:
 
-```
-sk-...
-```
+    ```plaintext
+    sk-...
+    ```
+
 2. Start the project with the OpenAI configuration:
 
-```
-docker compose -f compose.yaml -f compose.openai.yaml up
-```
+    ```sh
+    docker compose -f compose.yaml -f compose.openai.yaml up
+    ```
 
 # Compose for Agents Demos - Classification
 
 | Demo | Agent System | Models | MCPs | project | compose |
 | ---- | ---- | ---- | ---- | ---- | ---- |
-| [A2A](https://github.com/a2a-agents/agent2agent) Multi-Agent Fact Checker | Multi-Agent | OpenAI | duckduckgo | [./a2a](./a2a) | [compose.yaml](./a2a/compose.yaml) | 
+| [A2A](https://github.com/a2a-agents/agent2agent) Multi-Agent Fact Checker | Multi-Agent | OpenAI | duckduckgo | [./a2a](./a2a) | [compose.yaml](./a2a/compose.yaml) |
 | [Agno](https://github.com/agno-agi/agno) agent that summarizes GitHub issues | Multi-Agent | qwen3(local) | github-official | [./agno](./agno) | [compose.yaml](./agno/compose.yaml) |
 | [Vercel AI-SDK](https://github.com/vercel/ai) Chat-UI for mixing MCPs and Model | Single Agent | llama3.2(local), qwen3(local) | wikipedia-mcp, brave, resend(email) | [./vercel](./vercel) | [compose.yaml](https://github.com/slimslenderslacks/scira-mcp-chat/blob/main/compose.yaml) |
 | [CrewAI](https://github.com/crewAIInc/crewAI) Marketing Strategy Agent | Multi-Agent | qwen3(local) | duckduckgo | [./crew-ai](./crew-ai) | [compose.yaml](https://github.com/docker/compose-agents-demo/blob/main/crew-ai/compose.yaml) |
 | [ADK](https://github.com/google/adk-python) Multi-Agent Fact Checker | Multi-Agent | gemma3-qat(local) | duckduckgo | [./adk](./adk) | [compose.yaml](./adk/compose.yaml) |
-| [ADK](https://github.com/google/adk-python) & [Cerebras](https://www.cerebras.ai/) Golang Experts | Multi-Agent | unsloth/qwen3-gguf:4B-UD-Q4_K_XL & ai/qwen2.5:latest (DMR local), llama-4-scout-17b-16e-instruct (Cerebras remote) |  | [./adk-cerebras](./adk-cerebras) | [compose.yml](./adk-cerebras/compose.yml) | 
+| [ADK](https://github.com/google/adk-python) & [Cerebras](https://www.cerebras.ai/) Golang Experts | Multi-Agent | unsloth/qwen3-gguf:4B-UD-Q4_K_XL & ai/qwen2.5:latest (DMR local), llama-4-scout-17b-16e-instruct (Cerebras remote) |  | [./adk-cerebras](./adk-cerebras) | [compose.yml](./adk-cerebras/compose.yml) |
 | [LangGraph](https://github.com/langchain-ai/langgraph) SQL Agent | Single Agent | qwen3(local) | postgres | [./langgraph](./langgraph) | [compose.yaml](./langgraph/compose.yaml) |
 | [Embabel](https://github.com/embabel/embabel-agent) Travel Agent | Multi-Agent | qwen3, Claude3.7, llama3.2, jimclark106/all-minilm:23M-F16 | brave, github-official, wikipedia-mcp, weather, google-maps, airbnb | [./embabel](./embabel) | [compose.yaml](https://github.com/embabel/travel-planner-agent/blob/main/compose.yaml) and [compose.dmr.yaml](https://github.com/embabel/travel-planner-agent/blob/main/compose.dmr.yaml) |
 | [Spring AI](https://spring.io/projects/spring-ai) Brave Search | Single Agent | none | duckduckgo | [./spring-ai](./spring-ai) | [compose.yaml](./spring-ai/compose.yaml) |
@@ -54,3 +61,9 @@ made by Docker in this repository.
 > apply to that specific example, and they must be respected accordingly.
 
 `SPDX-License-Identifier: Apache-2.0 OR MIT`
+
+[Docker Compose]: https://github.com/docker/compose
+[Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Engine]: https://docs.docker.com/engine/
+[Docker Model Runner requirements]: https://docs.docker.com/ai/model-runner/
+[Docker Offload]: https://www.docker.com/products/docker-offload/

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,0 +1,21 @@
+version: '3'
+
+vars:
+  MARKDOWN_CLI2_CMD: docker run --rm -v $(pwd):/workdir davidanson/markdownlint-cli2:v0.18.1
+
+tasks:
+  lint:markdown:
+    desc: Lint Markdown files
+    cmds:
+      - "{{ .MARKDOWN_CLI2_CMD }}"
+    dir: .
+  lint:markdown:fix:
+    desc: Lint and Fix Markdown files
+    cmds:
+      - "{{ .MARKDOWN_CLI2_CMD }} --fix"
+    dir: .
+
+  lint:
+    deps:
+      - lint:markdown
+    desc: Lint all files

--- a/a2a/README.md
+++ b/a2a/README.md
@@ -10,7 +10,6 @@ internal reasoning alone. The system showcases how agents with distinct roles an
 > [!Tip]
 > ✨ No configuration needed — run it with a single command.
 
-
 <p align="center">
   <img src="demo.gif"
        alt="A2A Multi-Agent Fact Check Demo"
@@ -22,17 +21,20 @@ internal reasoning alone. The system showcases how agents with distinct roles an
 
 ### Requirements
 
-+ **[Docker Desktop](https://www.docker.com/products/docker-desktop/) 4.43.0+ or [Docker Engine](https://docs.docker.com/engine/)** installed
-+ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you don't have a GPU, you can alternatively use [**Docker Offload**](https://www.docker.com/products/docker-offload).
-+ If you're using Docker Engine on Linux or Docker Desktop on Windows, ensure that the [Docker Model Runner requirements](https://docs.docker.com/ai/model-runner/) are met (specifically that GPU support is enabled) and the necessary drivers are installed
-+ If you're using Docker Engine on Linux, ensure you have Compose 2.38.1 or later installed
-+ An [OpenAI API Key](https://platform.openai.com/api-keys) 🔑
++ **[Docker Desktop] 4.43.0+ or [Docker Engine]** installed.
++ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you
+  don't have a GPU, you can alternatively use **[Docker Offload]**.
++ If you're using [Docker Engine] on Linux or [Docker Desktop] on Windows, ensure that the
+  [Docker Model Runner requirements] are met (specifically that GPU
+  support is enabled) and the necessary drivers are installed.
++ If you're using Docker Engine on Linux, ensure you have [Docker Compose] 2.38.1 or later installed.
++ An [OpenAI API Key](https://platform.openai.com/api-keys) 🔑.
 
 ### Run the project
 
 Create a `secret.openai-api-key` file with your OpenAI API key:
 
-```
+```plaintext
 sk-...
 ```
 
@@ -61,18 +63,17 @@ same demo with a larger model that takes advantage of a more powerful GPU on the
 docker compose -f compose.dmr.yaml -f compose.offload.yaml up --build
 ```
 
-
 # ❓ What Can It Do?
 
 This system performs multi-agent fact verification, coordinated by an **Auditor**:
 
-- 🧑‍⚖️ **Auditor**:
-  - Orchestrates the process from input to verdict.
-  - Delegates tasks to Critic and Reviser agents.
-- 🧠 **Critic**:
-	- Uses DuckDuckGo via MCP to gather real-time external evidence.
--	✍️ **Reviser**:
-	- Refines and verifies the Critic’s conclusions using only reasoning.
++ 🧑‍⚖️ **Auditor**:
+  * Orchestrates the process from input to verdict.
+  * Delegates tasks to Critic and Reviser agents.
++ 🧠 **Critic**:
+  * Uses DuckDuckGo via MCP to gather real-time external evidence.
++ ✍️ **Reviser**:
+  * Refines and verifies the Critic’s conclusions using only reasoning.
 
 **🧠 All agents use the Docker Model Runner for LLM-based inference.**
 
@@ -88,7 +89,6 @@ Example question:
 | `Dockerfile`    | Builds the agent container              |
 | `src/AgentKit`  | Agent runtime                           |
 | `agents/*.yaml` | Agent definitions                       |
-
 
 # 🔧 Architecture Overview
 
@@ -115,10 +115,10 @@ flowchart TD
 
 ```
 
-- The Auditor is a Sequential Agent, it coordinates Critic and Reviser agents to verify user-provided claims.
-- The Critic agent performs live web searches through DuckDuckGo using an MCP-compatible gateway.
-- The Reviser agent refines the Critic’s conclusions using internal reasoning alone.
-- All agents run inference through a Docker-hosted Model Runner, enabling fully containerized LLM reasoning.
++ The Auditor is a Sequential Agent, it coordinates Critic and Reviser agents to verify user-provided claims.
++ The Critic agent performs live web searches through DuckDuckGo using an MCP-compatible gateway.
++ The Reviser agent refines the Critic’s conclusions using internal reasoning alone.
++ All agents run inference through a Docker-hosted Model Runner, enabling fully containerized LLM reasoning.
 
 # 🤝 Agent Roles
 
@@ -128,7 +128,6 @@ flowchart TD
 | **Critic**  | ✅ DuckDuckGo via MCP | Gathers evidence to support or refute the claim                              |
 | **Reviser** | ❌ None               | Refines and finalizes the answer without external input                      |
 
-
 # 🧹 Cleanup
 
 To stop and remove containers and volumes:
@@ -137,15 +136,16 @@ To stop and remove containers and volumes:
 docker compose down -v
 ```
 
-
 # 📎 Credits
-- [A2A]
-- [DuckDuckGo]
-- [Docker Compose]
 
++ [A2A]
++ [DuckDuckGo]
++ [Docker Compose]
 
 [A2A]: https://github.com/a2aproject/a2a-python
 [DuckDuckGo]: https://duckduckgo.com
 [Docker Compose]: https://github.com/docker/compose
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
-[Docker Model Runner]: https://docs.docker.com/ai/model-runner/
+[Docker Engine]: https://docs.docker.com/engine/
+[Docker Model Runner requirements]: https://docs.docker.com/ai/model-runner/
+[Docker Offload]: https://www.docker.com/products/docker-offload/

--- a/adk-cerebras/README.md
+++ b/adk-cerebras/README.md
@@ -1,31 +1,39 @@
 # DevDuck agents
 
-A multi-agent system for Go programming assistance built with Google Agent Development Kit (ADK). This project features a coordinating agent (DevDuck) that manages two specialized sub-agents (Bob and Cerebras) for different programming tasks.
+A multi-agent system for Go programming assistance built with Google Agent Development Kit (ADK). This
+project features a coordinating agent (DevDuck) that manages two specialized sub-agents (Bob and
+Cerebras) for different programming tasks.
 
 ## Architecture
 
-The system consists of three main agents orchestrated by Docker Compose, which plays a **primordial role** in launching and coordinating all agent services:
+The system consists of three main agents orchestrated by Docker Compose, which plays a
+**primordial role** in launching and coordinating all agent services:
 
 ### 🐙 Docker Compose Orchestration
+
 - **Central Role**: Docker Compose serves as the foundation for the entire multi-agent system
 - **Service Orchestration**: Manages the lifecycle of all three agents (DevDuck, Bob, and Cerebras)
-- **Configuration Management**: Defines agent prompts, model configurations, and service dependencies directly in the compose file
+- **Configuration Management**: Defines agent prompts, model configurations, and service dependencies
+  directly in the compose file
 - **Network Coordination**: Establishes secure inter-agent communication channels
 - **Environment Management**: Handles API keys, model parameters, and runtime configurations
 
-### Agent Components:
+### Agent Components
 
 ### 🦆 DevDuck (Main Agent)
+
 - **Role**: Main development assistant and project coordinator
 - **Model**: Qwen3 (unsloth/qwen3-gguf:4B-UD-Q4_K_XL)
 - **Capabilities**: Routes requests to appropriate sub-agents based on user needs
 
 ### 👨‍💻 Bob Agent
+
 - **Role**: General development tasks and project coordination
 - **Model**: Qwen2.5 (ai/qwen2.5:latest)
 - **Specialization**: Go programming expert for understanding code, explaining concepts, and generating code snippets
 
 ### 🧠 Cerebras Agent
+
 - **Role**: Advanced computational tasks and complex problem-solving
 - **Model**: Llama-4 Scout (llama-4-scout-17b-16e-instruct)
 - **Provider**: Cerebras API
@@ -43,14 +51,17 @@ The system consists of three main agents orchestrated by Docker Compose, which p
 
 ### Prerequisites
 
-+ **[Docker Desktop](https://www.docker.com/products/docker-desktop/) 4.43.0+ or [Docker Engine](https://docs.docker.com/engine/)** installed
-+ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you don't have a GPU, you can alternatively use [**Docker Offload**](https://www.docker.com/products/docker-offload).
-+ If you're using Docker Engine on Linux or Docker Desktop on Windows, ensure that the [Docker Model Runner requirements](https://docs.docker.com/ai/model-runner/) are met (specifically that GPU support is enabled) and the necessary drivers are installed
-+ If you're using Docker Engine on Linux, ensure you have Compose 2.38.1 or later installed
+- **[Docker Desktop] 4.43.0+ or [Docker Engine]** installed.
+- **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you
+  don't have a GPU, you can alternatively use **[Docker Offload]**.
+- If you're using [Docker Engine] on Linux or [Docker Desktop] on Windows, ensure that the
+  [Docker Model Runner requirements] are met (specifically that GPU
+  support is enabled) and the necessary drivers are installed.
+- If you're using Docker Engine on Linux, ensure you have [Docker Compose] 2.38.1 or later installed.
 
 ### Configuration
 
-1. **You need a Cerebras API Key**: https://cloud.cerebras.ai/
+1. **You need a Cerebras API Key**: <https://cloud.cerebras.ai/>
 2. Create a `.env` file with the following content:
 
 ```env
@@ -58,6 +69,7 @@ CEREBRAS_API_KEY=<your_cerebras_api_key>
 CEREBRAS_BASE_URL=https://api.cerebras.ai/v1
 CEREBRAS_CHAT_MODEL=llama-4-scout-17b-16e-instruct
 ```
+
 > look at the `.env.sample` file
 
 ### ✋ All the prompts are defined in the 🐙 compose file
@@ -71,7 +83,6 @@ docker compose up
 
 The application will be available at [http://0.0.0.0:8000](http://0.0.0.0:8000)
 
-
 ### Usage
 
 The agents can be accessed through the web interface or API endpoints.
@@ -79,6 +90,7 @@ The agents can be accessed through the web interface or API endpoints.
 > Activate Token Streaming
 
 **You can try this**:
+
 ```text
 Hello I'm Phil
 
@@ -90,6 +102,7 @@ Cerebras can you analyse and comment this code
 
 Can you generate the tests
 ```
+
 > ✋ For a public demo, stay simple, the above examples are working.
 
 **🎥 How to use the demo**: [https://youtu.be/WYB31bzfXnM](https://youtu.be/WYB31bzfXnM)
@@ -97,13 +110,20 @@ Can you generate the tests
 #### Routing Requests
 
 - **General requests**: Handled by DevDuck, who routes to appropriate sub-agents
-- **Specific agent requests**: 
-  - "I want to speak with Bob" → Routes to Bob agent
-  - "I want to speak with Cerebras" → Routes to Cerebras agent
+- **Specific agent requests**
+  + "I want to speak with Bob" → Routes to Bob agent
+  + "I want to speak with Cerebras" → Routes to Cerebras agent
 
 ## Tips
 
 If for any reason, you cannot go back from the Cerebras agent to the Bob agent, try this:
+
 ```text
 go back to devduck
 ```
+
+[Docker Compose]: https://github.com/docker/compose
+[Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Engine]: https://docs.docker.com/engine/
+[Docker Model Runner requirements]: https://docs.docker.com/ai/model-runner/
+[Docker Offload]: https://www.docker.com/products/docker-offload/

--- a/adk-sock-shop/CLAUDE.md
+++ b/adk-sock-shop/CLAUDE.md
@@ -5,12 +5,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Development Commands
 
 ### Build and Run
+
 ```bash
 # Build and push multi-platform image (requires hydrobuild builder)
 make build-adk-image
 ```
 
 ### Development Tools
+
 ```bash
 # Type checking
 pyright
@@ -21,7 +23,8 @@ ruff format
 ```
 
 ### Testing and Development
-- Access the web interface at `http://localhost:8080` after running `docker compose up --build`
+
+- Access the web interface at <http://localhost:8080> after running `docker compose up --build`
 - Use Google Cloud Run deployment with `compose.gcloudrun.yaml` for cloud deployment
 
 ## Architecture Overview
@@ -29,21 +32,23 @@ ruff format
 This is an **ADK (Agent Development Kit) multi-agent fact-checking system** with three coordinated agents:
 
 ### Agent Hierarchy
+
 - **Root Agent**: `llm_auditor` (SequentialAgent) at `agents/agent.py:22`
-  - Orchestrates the entire fact-checking workflow
-  - Coordinates between Critic and Reviser agents sequentially
+  + Orchestrates the entire fact-checking workflow
+  + Coordinates between Critic and Reviser agents sequentially
   
 - **Critic Agent**: `agents/sub_agents/critic/agent.py:27`
-  - Has access to DuckDuckGo search via MCP (Model Context Protocol)
-  - Gathers external evidence to support or refute claims
-  - Uses `mcp/duckduckgo:search` toolset
+  + Has access to DuckDuckGo search via MCP (Model Context Protocol)
+  + Gathers external evidence to support or refute claims
+  + Uses `mcp/duckduckgo:search` toolset
   
 - **Reviser Agent**: `agents/sub_agents/reviser/agent.py:97`
-  - No external tools - pure reasoning agent
-  - Refines conclusions based on Critic's findings
-  - Uses content processing callbacks for model compatibility
+  + No external tools - pure reasoning agent
+  + Refines conclusions based on Critic's findings
+  + Uses content processing callbacks for model compatibility
 
 ### Agent Communication Pattern
+
 1. User submits question → Auditor
 2. Auditor → Critic (with search tools)
 3. Critic gathers evidence → Auditor
@@ -52,15 +57,18 @@ This is an **ADK (Agent Development Kit) multi-agent fact-checking system** with
 6. Auditor delivers final answer
 
 ### Special Implementation Notes
+
 - Reviser agent uses content preprocessing callbacks (`force_string_content`, `_remove_end_of_edit_mark`) for model compatibility
 - MCP tools are configured via `create_mcp_toolsets()` in critic agent
 - All agents use LiteLLM for model abstraction with OpenAI format
 
 ### Generating a compose.yaml file
 
-* To add models and gateways to an existing compose.yaml file, you should figure out which model you want to use, and which mcp servers are needed.
-* Create a service entry like the following
-    ```
+- To add models and gateways to an existing compose.yaml file, you should figure out which model you
+  want to use, and which mcp servers are needed.
+- Create a service entry like the following:
+
+    ```yaml
     mcp-gateway:
       image: docker/mcp-gateway:latest
       use_api_socket: true
@@ -72,29 +80,40 @@ This is an **ADK (Agent Development Kit) multi-agent fact-checking system** with
       secrets:
         - mcp_secret
     ```
+
     but replace the servers value with a comma-separate list of the MCP servers that you want to use.
-* Also, if there is no top-level `secrets` entry with a `mcp_secret` entry then add one.  It should look like:
-    ```
+
+- Also, if there is no top-level `secrets` entry with a `mcp_secret` entry then add one. It should look
+  like:
+
+    ```yaml
     secrets:
       mcp_secret:
         file: ./.mcp.env
     ```
+
   and remind that the user that Docker offload will require secrets to be stored in a local file named .mcp.env
-* Whenever a model is needed, add a toplevel entry in the compose.yaml file with the name of the model.  It should look like:
-    ```
+
+- Whenever a model is needed, add a toplevel entry in the compose.yaml file with the name of the
+  model.  It should look like:
+  
+    ```yaml
     models:
       <model_name>:
         model: <model_image_ref>
     ```
+
     but replace the <model_name> with whatever model the user wants to use.
     If the user wnts the model_name qwen3 then the model_image_ref should be ai/qwen3:14B-Q6_K
-  * whenever a model is added, the user must specify what service needs the model.
+- Whenever a model is added, the user must specify what service needs the model.
     Add a new entry to that service's definition with the following content.
 
-    ```
+    ```yaml
     models:
       <model_name>:
         endpoint_var: MODEL_RUNNER_URL
         model_var: MODEL_RUNNER_MODEL
     ```
-    If it's unclear which service needs this definition then ask. Always add the model to just the service definition that needs it.
+
+    If it's unclear which service needs this definition then ask. Always add the model to just the
+    service definition that needs it.

--- a/adk-sock-shop/README.md
+++ b/adk-sock-shop/README.md
@@ -7,7 +7,13 @@
 
 ### Requirements
 
-- 🐳 [Docker Desktop] **v4.43.0+**
++ **[Docker Desktop] 4.43.0+ or [Docker Engine]** installed.
++ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you
+  don't have a GPU, you can alternatively use **[Docker Offload]**.
++ If you're using [Docker Engine] on Linux or [Docker Desktop] on Windows, ensure that the
+  [Docker Model Runner requirements] are met (specifically that GPU
+  support is enabled) and the necessary drivers are installed.
++ If you're using Docker Engine on Linux, ensure you have [Docker Compose] 2.38.1 or later installed.
 
 ### Run the project
 
@@ -19,6 +25,7 @@ export RESEND_API_KEY=<resend_api_key>
 export OPENAI_API_KEY=<openai_api_key>
 make gateway-secrets
 ```
+
 If you're running with an arm64 macos machine, then initialize the environment with one additional command:
 
 ```sh
@@ -31,16 +38,17 @@ To start up the Sock Store and the Agent portal, run:
 docker compose up --build
 ```
 
-* Open [*http://localhost:9090*](http://localhost:9090) to see the sock store.
-* Open [*http://localhost:3000*](http://localhost:3000) to see the Sock Vendor Agent Portal.
-
++ Open [*http://localhost:9090*](http://localhost:9090) to see the sock store.
++ Open [*http://localhost:3000*](http://localhost:3000) to see the Sock Vendor Agent Portal.
 
 # ❓ What Can It Do?
 
 Example input to the portal:
 
-> “I am a sock vendor named Nike. Perhaps you've heard of us. We provide colorful compressions socks, that are elegant and affordable.  Our Nike compression socks are 12.99 each.  
-   Here are some urls to images of the socks https://tinyurl.com/5n6spnvu and https://tinyurl.com/mv8ebjnh"
+> “I am a sock vendor named Nike. Perhaps you've heard of us. We provide colorful compressions socks,
+> that are elegant and affordable.  Our Nike compression socks are 12.99 each.  
+> Here are some urls to images of the socks <https://tinyurl.com/5n6spnvu> and
+> <https://tinyurl.com/mv8ebjnh>"
 
 # 🔧 Architecture Overview
 
@@ -73,9 +81,13 @@ docker compose down -v
 ```
 
 # 📎 Credits
-- [ADK]
-- [Docker Compose]
+
++ [ADK]
++ [Docker Compose]
 
 [ADK]: https://google.github.io/adk-docs/
 [Docker Compose]: https://github.com/docker/compose
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Engine]: https://docs.docker.com/engine/
+[Docker Model Runner requirements]: https://docs.docker.com/ai/model-runner/
+[Docker Offload]: https://www.docker.com/products/docker-offload/

--- a/adk/README.md
+++ b/adk/README.md
@@ -9,7 +9,6 @@ with distinct roles and tools can **collaborate under orchestration**.
 > [!Tip]
 > ✨ No configuration needed — run it with a single command.
 
-
 <p align="center">
   <img src="demo.gif"
        alt="ADK Multi-Agent Fact Check Demo"
@@ -21,57 +20,61 @@ with distinct roles and tools can **collaborate under orchestration**.
 
 ### Requirements
 
-+ **[Docker Desktop](https://www.docker.com/products/docker-desktop/) 4.43.0+ or [Docker Engine](https://docs.docker.com/engine/)** installed
-+ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you don't have a GPU, you can alternatively use [**Docker Offload**](https://www.docker.com/products/docker-offload).
-+ If you're using Docker Engine on Linux or Docker Desktop on Windows, ensure that the [Docker Model Runner requirements](https://docs.docker.com/ai/model-runner/) are met (specifically that GPU support is enabled) and the necessary drivers are installed
-+ If you're using Docker Engine on Linux, ensure you have Compose 2.38.1 or later installed
++ **[Docker Desktop] 4.43.0+ or [Docker Engine]** installed.
++ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you
+  don't have a GPU, you can alternatively use **[Docker Offload]**.
++ If you're using [Docker Engine] on Linux or [Docker Desktop] on Windows, ensure that the
+  [Docker Model Runner requirements] are met (specifically that GPU
+  support is enabled) and the necessary drivers are installed.
++ If you're using Docker Engine on Linux, ensure you have [Docker Compose] 2.38.1 or later installed.
 
 ### Run the project
-
 
 ```sh
 docker compose up --build
 ```
 
-Using Docker Offload with GPU support, you can run the same demo with a larger model that takes advantage of a more powerful GPU on the remote instance:
+Using Docker Offload with GPU support, you can run the same demo with a larger model that takes
+advantage of a more powerful GPU on the remote instance:
+
 ```sh
 docker compose -f compose.yaml -f compose.offload.yaml up --build
 ```
 
-
-No configuration needed — everything runs from the container. Open `http://localhost:8080` in your browser to
-chat with the agents.
+No configuration needed — everything runs from the container. Open `http://localhost:8080` in your
+browser to chat with the agents.
 
 # 🧠 Inference Options
 
-By default, this project uses [Docker Model Runner] to handle LLM inference locally — no internet connection or external API key is required.
+By default, this project uses [Docker Model Runner] to handle LLM inference locally — no internet
+connection or external API key is required.
 
 If you’d prefer to use OpenAI instead:
 
 1. Create a `secret.openai-api-key` file with your OpenAI API key:
 
-```
-sk-...
-```
+    ```plaintext
+    sk-...
+    ```
 
 2. Restart the project with the OpenAI configuration:
 
-```
-docker compose down -v
-docker compose -f compose.yaml -f compose.openai.yaml up
-```
+    ```sh
+    docker compose down -v
+    docker compose -f compose.yaml -f compose.openai.yaml up
+    ```
 
 # ❓ What Can It Do?
 
 This system performs multi-agent fact verification, coordinated by an **Auditor**:
 
-- 🧑‍⚖️ **Auditor**:
-  - Orchestrates the process from input to verdict.
-  - Delegates tasks to Critic and Reviser agents.
-- 🧠 **Critic**:
-	- Uses DuckDuckGo via MCP to gather real-time external evidence.
--	✍️ **Reviser**:
-	- Refines and verifies the Critic’s conclusions using only reasoning.
++ 🧑‍⚖️ **Auditor**:
+  * Orchestrates the process from input to verdict.
+  * Delegates tasks to Critic and Reviser agents.
++ 🧠 **Critic**:
+  * Uses DuckDuckGo via MCP to gather real-time external evidence.
++ ✍️ **Reviser**:
+  * Refines and verifies the Critic’s conclusions using only reasoning.
 
 **🧠 All agents use the Docker Model Runner for LLM-based inference.**
 
@@ -88,7 +91,6 @@ Example question:
 | `agents/agent.py`    | Auditor agent coordinating between the critic and the reviser |
 | `agents/`            | Contains core logic for critic and reviser agents             |
 | `agents/sub_agents/` | Submodules for critic and reviser roles                       |
-
 
 # 🔧 Architecture Overview
 
@@ -115,10 +117,10 @@ flowchart TD
 
 ```
 
-- The Auditor is a Sequential Agent, it coordinates Critic and Reviser agents to verify user-provided claims.
-- The Critic agent performs live web searches through DuckDuckGo using an MCP-compatible gateway.
-- The Reviser agent refines the Critic’s conclusions using internal reasoning alone.
-- All agents run inference through a Docker-hosted Model Runner, enabling fully containerized LLM reasoning.
++ The Auditor is a Sequential Agent, it coordinates Critic and Reviser agents to verify user-provided claims.
++ The Critic agent performs live web searches through DuckDuckGo using an MCP-compatible gateway.
++ The Reviser agent refines the Critic’s conclusions using internal reasoning alone.
++ All agents run inference through a Docker-hosted Model Runner, enabling fully containerized LLM reasoning.
 
 # 🤝 Agent Roles
 
@@ -128,7 +130,6 @@ flowchart TD
 | **Critic**  | ✅ DuckDuckGo via MCP | Gathers evidence to support or refute the claim                              |
 | **Reviser** | ❌ None               | Refines and finalizes the answer without external input                      |
 
-
 # 🧹 Cleanup
 
 To stop and remove containers and volumes:
@@ -137,15 +138,17 @@ To stop and remove containers and volumes:
 docker compose down -v
 ```
 
-
 # 📎 Credits
-- [ADK]
-- [DuckDuckGo]
-- [Docker Compose]
 
++ [ADK]
++ [DuckDuckGo]
++ [Docker Compose]
 
 [ADK]: https://google.github.io/adk-docs/
 [DuckDuckGo]: https://duckduckgo.com
 [Docker Compose]: https://github.com/docker/compose
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Engine]: https://docs.docker.com/engine/
 [Docker Model Runner]: https://docs.docker.com/ai/model-runner/
+[Docker Model Runner requirements]: https://docs.docker.com/ai/model-runner/
+[Docker Offload]: https://www.docker.com/products/docker-offload/

--- a/agno/README.md
+++ b/agno/README.md
@@ -1,6 +1,9 @@
 # 🧠 Agno GitHub Issue Analyzer
 
-This project demonstrates a **collaborative multi-agent system** built with [Agno], where specialized agents work together to analyze GitHub repositories. The **Coordinator** orchestrates the workflow between a **GitHub Issue Retriever** agent that fetches open issues via the **GitHub MCP Server**, and a **Writer** agent that summarizes and categorizes them into a comprehensive markdown report.
+This project demonstrates a **collaborative multi-agent system** built with [Agno], where specialized
+agents work together to analyze GitHub repositories. The **Coordinator** orchestrates the workflow
+between a **GitHub Issue Retriever** agent that fetches open issues via the **GitHub MCP Server**, and
+a **Writer** agent that summarizes and categorizes them into a comprehensive markdown report.
 
 > [!Tip]
 > ✨ No complex configuration needed — just add your GitHub token and run with a single command.
@@ -9,16 +12,19 @@ This project demonstrates a **collaborative multi-agent system** built with [Agn
 
 ### Requirements
 
-+ **[Docker Desktop](https://www.docker.com/products/docker-desktop/) 4.43.0+ or [Docker Engine](https://docs.docker.com/engine/)** installed
-+ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you don't have a GPU, you can alternatively use [**Docker Offload**](https://www.docker.com/products/docker-offload).
-+ If you're using Docker Engine on Linux or Docker Desktop on Windows, ensure that the [Docker Model Runner requirements](https://docs.docker.com/ai/model-runner/) are met (specifically that GPU support is enabled) and the necessary drivers are installed
-+ If you're using Docker Engine on Linux, ensure you have Compose 2.38.1 or later installed
++ **[Docker Desktop] 4.43.0+ or [Docker Engine]** installed.
++ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you
+  don't have a GPU, you can alternatively use **[Docker Offload]**.
++ If you're using [Docker Engine] on Linux or [Docker Desktop] on Windows, ensure that the
+  [Docker Model Runner requirements] are met (specifically that GPU
+  support is enabled) and the necessary drivers are installed.
++ If you're using Docker Engine on Linux, ensure you have [Docker Compose] 2.38.1 or later installed.
 + 🔑 GitHub Personal Access Token (for public repositories)
 
 ### Setup
 
 1. **Create a GitHub Personal Access Token:**
-   - Navigate to https://github.com/settings/personal-access-tokens
+   - Navigate to <https://github.com/settings/personal-access-tokens>
    - Create a fine-grained token with **read access to public repositories**
 
    ![GitHub token permissions](./img/github-perms.png)
@@ -26,7 +32,8 @@ This project demonstrates a **collaborative multi-agent system** built with [Agn
 2. **Configure MCP secrets:**
    - Copy `.mcp.env.example` to `.mcp.env`
    - Add your GitHub token to the `.mcp.env` file:
-   ```bash
+  
+   ```sh
    GITHUB_PERSONAL_ACCESS_TOKEN=your_token_here
    ```
 
@@ -36,44 +43,49 @@ This project demonstrates a **collaborative multi-agent system** built with [Agn
 docker compose up --build
 ```
 
-Using Docker Offload with GPU support, you can run the same demo with a larger model that takes advantage of a more powerful GPU on the remote instance:
+Using Docker Offload with GPU support, you can run the same demo with a larger model that takes advantage
+of a more powerful GPU on the remote instance:
+
 ```sh
 docker compose -f compose.yaml -f compose.offload.yaml up --build
 ```
 
-That's all! The agents will spin up automatically. Open **http://localhost:3000** in your browser to interact with the multi-agent system.
+That's all! The agents will spin up automatically. Open **<http://localhost:3000>** in your browser to
+interact with the multi-agent system.
 
 # 🧠 Inference Options
 
-By default, this project uses [Docker Model Runner] to handle LLM inference locally — no internet connection or external API key is required.
+By default, this project uses [Docker Model Runner] to handle LLM inference locally — no internet
+connection or external API key is required.
 
 If you’d prefer to use OpenAI instead:
 
 1. Create a `secret.openai-api-key` file with your OpenAI API key:
 
-```
-sk-...
-```
+      ```plaintext
+      sk-...
+      ```
 
 2. Restart the project with the OpenAI configuration:
 
-```
-docker compose down -v
-docker compose -f compose.yaml -f compose.openai.yaml up
-```
+      ```sh
+      docker compose down -v
+      docker compose -f compose.yaml -f compose.openai.yaml up
+      ```
 
 # ❓ What Can It Do?
 
 Give it any public GitHub repository and watch the agents collaborate to deliver a comprehensive analysis:
 
-- **Fetch Issues**: The GitHub agent retrieves all open issues with their details
-- **Analyze & Categorize**: The Writer agent classifies issues into categories (bugs, features, documentation)
-- **Generate Report**: Creates a structured markdown summary with issue links and descriptions
++ **Fetch Issues**: The GitHub agent retrieves all open issues with their details
++ **Analyze & Categorize**: The Writer agent classifies issues into categories (bugs, features, documentation)
++ **Generate Report**: Creates a structured markdown summary with issue links and descriptions
 
 **Example queries:**
-- `summarize the issues in the repo microsoft/vscode`
-- `analyze issues in facebook/react`
-- `categorize the problems in tensorflow/tensorflow`
+
++ `summarize the issues in the repo microsoft/vscode`
++ `analyze issues in facebook/react`
++ `categorize the problems in tensorflow/tensorflow`
 
 The **Coordinator** orchestrates the entire workflow, ensuring each agent performs its specialized task efficiently.
 
@@ -122,21 +134,22 @@ flowchart TD
     end
 ```
 
-- The **Coordinator** orchestrates the multi-agent workflow using Agno's team coordination
-- **GitHub Issue Retriever** connects to GitHub via the secure MCP Gateway
-- **Writer** processes and categorizes the retrieved data into structured reports
-- All agents use **Docker Model Runner** with Qwen 3 for local LLM inference
-- The **Next.js UI** provides an intuitive chat interface for repository analysis
++ The **Coordinator** orchestrates the multi-agent workflow using Agno's team coordination
++ **GitHub Issue Retriever** connects to GitHub via the secure MCP Gateway
++ **Writer** processes and categorizes the retrieved data into structured reports
++ All agents use **[Docker Model Runner]** with Qwen 3 for local LLM inference
++ The **Next.js UI** provides an intuitive chat interface for repository analysis
 
 # 🛠️ Agent Configuration
 
 The agents are configured in `agents.yaml` with specific roles and instructions:
 
-- **GitHub Agent**: Specialized in retrieving GitHub issues with precise API calls
-- **Writer Agent**: Expert in summarization and categorization with markdown formatting
-- **Coordinator Team**: Orchestrates the workflow between specialized agents
++ **GitHub Agent**: Specialized in retrieving GitHub issues with precise API calls
++ **Writer Agent**: Expert in summarization and categorization with markdown formatting
++ **Coordinator Team**: Orchestrates the workflow between specialized agents
 
-Each agent uses the **Docker Model Runner** for inference, ensuring consistent performance without external API dependencies.
+Each agent uses the **[Docker Model Runner]** for inference, ensuring consistent performance without
+external API dependencies.
 
 # 🧹 Cleanup
 
@@ -148,12 +161,15 @@ docker compose down -v
 
 # 📎 Credits
 
-- [Agno] - Multi-agent framework
-- [GitHub MCP Server] - Model Context Protocol integration
-- [Docker Compose] - Container orchestration
++ [Agno] - Multi-agent framework
++ [GitHub MCP Server] - Model Context Protocol integration
++ [Docker Compose] - Container orchestration
 
 [Agno]: https://github.com/agno-agi/agno
 [GitHub MCP Server]: https://github.com/modelcontextprotocol/servers
 [Docker Compose]: https://github.com/docker/compose
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Engine]: https://docs.docker.com/engine/
 [Docker Model Runner]: https://docs.docker.com/ai/model-runner/
+[Docker Model Runner requirements]: https://docs.docker.com/ai/model-runner/
+[Docker Offload]: https://www.docker.com/products/docker-offload/

--- a/agno/agent-ui/README.md
+++ b/agno/agent-ui/README.md
@@ -1,8 +1,10 @@
 # Agent UI
 
-A modern chat interface for AI agents built with Next.js, Tailwind CSS, and TypeScript. This template provides a ready-to-use UI for interacting with Agno agents.
+A modern chat interface for AI agents built with Next.js, Tailwind CSS, and TypeScript. This template
+provides a ready-to-use UI for interacting with Agno agents.
 
-<img src="https://github.com/user-attachments/assets/7765fae5-a813-46cb-993b-904af9bc1672" alt="agent-ui" style="border-radius: 10px; width: 100%; max-width: 800px;" />
+<img src="https://github.com/user-attachments/assets/7765fae5-a813-46cb-993b-904af9bc1672" alt="agent-ui"
+style="border-radius: 10px; width: 100%; max-width: 800px;" />
 
 ## Features
 
@@ -18,7 +20,9 @@ A modern chat interface for AI agents built with Next.js, Tailwind CSS, and Type
 
 ### Prerequisites
 
-Before setting up Agent UI, you may want to have an Agno Playground running. If you haven't set up the Agno Playground yet, follow the [official guide](https://agno.link/agent-ui#connect-to-local-agents) to run the Playground locally.
+Before setting up Agent UI, you may want to have an Agno Playground running. If you haven't set up the
+Agno Playground yet, follow the [official guide](https://agno.link/agent-ui#connect-to-local-agents)
+to run the Playground locally.
 
 ### Installation
 
@@ -32,28 +36,29 @@ npx create-agent-ui@latest
 
 1. Clone the repository:
 
-```bash
-git clone https://github.com/agno-agi/agent-ui.git
-cd agent-ui
-```
+    ```bash
+    git clone https://github.com/agno-agi/agent-ui.git
+    cd agent-ui
+    ```
 
 2. Install dependencies:
 
-```bash
-pnpm install
-```
+    ```bash
+    pnpm install
+    ```
 
 3. Start the development server:
 
-```bash
-pnpm dev
-```
+    ```bash
+    pnpm dev
+    ```
 
 4. Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 ## Connecting to an Agent Backend
 
-By default Agent UI connects to `http://localhost:7777`. You can easily change this by hovering over the endpoint URL and clicking the edit option.
+By default Agent UI connects to `http://localhost:7777`. You can easily change this by hovering over the
+endpoint URL and clicking the edit option.
 
 The default endpoint works with the standard Agno Playground setup described in the [official documentation](https://agno.link/agent-ui#connect-to-local-agents).
 

--- a/crew-ai/README.md
+++ b/crew-ai/README.md
@@ -1,11 +1,12 @@
 # 🧠 CrewAI Marketing Team Demo
 
 This project showcases an autonomous, multi-agent **virtual marketing team** built with
-[CrewAI](https://github.com/joaomdmoura/crewAI). It automates the creation of a high-quality, end-to-end marketing strategy — from research to copywriting — using task delegation, web search, and creative synthesis.
+[CrewAI](https://github.com/joaomdmoura/crewAI). It automates the creation of a high-quality, end-to-end
+marketing strategy — from research to copywriting — using task delegation, web search, and creative
+synthesis.
 
 > [!Tip]
 > ✨ No configuration needed — run it with a single command.
-
 
 <p align="center">
   <img src="demo.gif"
@@ -18,11 +19,13 @@ This project showcases an autonomous, multi-agent **virtual marketing team** bui
 
 ### Requirements
 
-+ **[Docker Desktop](https://www.docker.com/products/docker-desktop/) 4.43.0+ or [Docker Engine](https://docs.docker.com/engine/)** installed
-+ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you don't have a GPU, you can alternatively use [**Docker Offload**](https://www.docker.com/products/docker-offload).
-+ If you're using Docker Engine on Linux or Docker Desktop on Windows, ensure that the [Docker Model Runner requirements](https://docs.docker.com/ai/model-runner/) are met (specifically that GPU support is enabled) and the necessary drivers are installed
-+ If you're using Docker Engine on Linux, ensure you have Compose 2.38.1 or later installed
-
++ **[Docker Desktop] 4.43.0+ or [Docker Engine]** installed.
++ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you
+  don't have a GPU, you can alternatively use **[Docker Offload]**.
++ If you're using [Docker Engine] on Linux or [Docker Desktop] on Windows, ensure that the
+  [Docker Model Runner requirements] are met (specifically that GPU
+  support is enabled) and the necessary drivers are installed.
++ If you're using Docker Engine on Linux, ensure you have [Docker Compose] 2.38.1 or later installed.
 
 ### Run the Project
 
@@ -35,37 +38,37 @@ deliver a complete marketing strategy for the input project.
 
 # 🧠 Inference Options
 
-By default, this project uses [Docker Model Runner] to handle LLM inference locally — no internet connection or external API key is required.
+By default, this project uses [Docker Model Runner] to handle LLM inference locally — no internet
+connection or external API key is required.
 
 If you’d prefer to use OpenAI instead:
 
 1. Create a `secret.openai-api-key` file with your OpenAI API key:
 
-```
-sk-...
-```
+    ```plaintext
+    sk-...
+    ```
 
 2. Restart the project with the OpenAI configuration:
 
-```
-docker compose down -v
-docker compose -f compose.yaml -f compose.openai.yaml up
-```
+    ```sh
+    docker compose down -v
+    docker compose -f compose.yaml -f compose.openai.yaml up
+    ```
 
 ## ❓ What Can It Do?
 
 Give it a company and a project description — the agents will collaborate to produce a full marketing strategy:
 
-- “Research the market landscape around CrewAI’s automation tools.”
-- “Understand the target audience for enterprise AI integrations.”
-- “Formulate a high-impact marketing strategy with KPIs and channels.”
-- “Propose 5 creative campaigns tailored to tech decision-makers.”
-- “Write compelling ad copy for each campaign idea.”
++ “Research the market landscape around CrewAI’s automation tools.”
++ “Understand the target audience for enterprise AI integrations.”
++ “Formulate a high-impact marketing strategy with KPIs and channels.”
++ “Propose 5 creative campaigns tailored to tech decision-makers.”
++ “Write compelling ad copy for each campaign idea.”
 
 From strategy to storytelling, the team handles it all — autonomously.
 
 You can **customize the tasks** to use your own domain and project description — just edit the inputs in `src/marketing_posts/config/inputs.yaml`.
-
 
 # 👥 Virtual Team Structure
 
@@ -76,7 +79,6 @@ You can **customize the tasks** to use your own domain and project description �
 | **Creative Content Creator**   | ✍️ creative_content_creator  | Writes compelling ad copy based on campaign ideas.                     |
 | **Chief Creative Director**    | 👑 chief_creative_director    | Reviews and approves all outputs for alignment and quality.            |
 
-
 # 🧱 Project Structure
 
 | File/Folder    | Purpose                                                |
@@ -85,8 +87,6 @@ You can **customize the tasks** to use your own domain and project description �
 | `Dockerfile`   | Builds the container environment.                      |
 | `src/config`   | Contains the agent, task definitions, and task inputs. |
 | `src/*.py`     | Main program and crew definition.                      |
-
-
 
 # 🔧 Architecture Overview
 
@@ -140,10 +140,9 @@ flowchart TD
     T5 --> Output[(📄 Final Deliverables<br/>Copy + Strategy + Campaigns)]
 ```
 
-- The LangGraph-based agent transforms questions into SQL.
-- PostgreSQL is populated from a SQLite dump at runtime.
-- All components are fully containerized for plug-and-play usage.
-
++ The LangGraph-based agent transforms questions into SQL.
++ PostgreSQL is populated from a SQLite dump at runtime.
++ All components are fully containerized for plug-and-play usage.
 
 # 🧹 Cleanup
 
@@ -153,16 +152,18 @@ To stop and remove containers and volumes:
 docker compose down -v
 ```
 
-
 # 📎 Credits
-- [crewAI]
-- [crewAI Marketing Strategy Example](https://github.com/crewAIInc/crewAI-examples/tree/main/marketing_strategy)
-- [DuckDuckGo]
-- [Docker Compose]
 
++ [crewAI]
++ [crewAI Marketing Strategy Example](https://github.com/crewAIInc/crewAI-examples/tree/main/marketing_strategy)
++ [DuckDuckGo]
++ [Docker Compose]
 
 [crewAI]: https://github.com/crewAIInc/crewAI
 [DuckDuckGo]: https://duckduckgo.com
 [Docker Compose]: https://github.com/docker/compose
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Engine]: https://docs.docker.com/engine/
 [Docker Model Runner]: https://docs.docker.com/ai/model-runner/
+[Docker Model Runner requirements]: https://docs.docker.com/ai/model-runner/
+[Docker Offload]: https://www.docker.com/products/docker-offload/

--- a/langgraph/README.md
+++ b/langgraph/README.md
@@ -1,15 +1,15 @@
 # 🧠 SQL Agent with LangGraph
 
-This project demonstrates a **zero-config AI agent** that uses [LangGraph] to answer natural language questions by querying a SQL database — all orchestrated with [Docker Compose].
+This project demonstrates a **zero-config AI agent** that uses [LangGraph] to answer natural language
+questions by querying a SQL database — all orchestrated with [Docker Compose].
 
 > [!Tip]
 > ✨ No configuration needed — run it with a single command.
 
-
 <p align="center">
-  <img src="demo.gif" 
+  <img src="demo.gif"
        alt="Demo"
-       width="50%" 
+       width="50%"
        style="border: 1px solid #ccc; border-radius: 8px;" />
 </p>
 
@@ -17,52 +17,59 @@ This project demonstrates a **zero-config AI agent** that uses [LangGraph] to an
 
 ### Requirements
 
-+ **[Docker Desktop](https://www.docker.com/products/docker-desktop/) 4.43.0+ or [Docker Engine](https://docs.docker.com/engine/)** installed
-+ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you don't have a GPU, you can alternatively use [**Docker Offload**](https://www.docker.com/products/docker-offload).
-+ If you're using Docker Engine on Linux or Docker Desktop on Windows, ensure that the [Docker Model Runner requirements](https://docs.docker.com/ai/model-runner/) are met (specifically that GPU support is enabled) and the necessary drivers are installed
-+ If you're using Docker Engine on Linux, ensure you have Compose 2.38.1 or later installed
++ **[Docker Desktop] 4.43.0+ or [Docker Engine]** installed.
++ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you
+  don't have a GPU, you can alternatively use **[Docker Offload]**.
++ If you're using [Docker Engine] on Linux or [Docker Desktop] on Windows, ensure that the
+  [Docker Model Runner requirements] are met (specifically that GPU
+  support is enabled) and the necessary drivers are installed.
++ If you're using Docker Engine on Linux, ensure you have [Docker Compose] 2.38.1 or later installed.
 
 ### Run the project
-
 
 ```sh
 docker compose up
 ```
 
-That’s all. The agent spins up automatically, sets up PostgreSQL, loads a pre-seeded database (`Chinook.db`), and starts answering your questions.
+That’s all. The agent spins up automatically, sets up PostgreSQL, loads a pre-seeded database
+(`Chinook.db`), and starts answering your questions.
 
 # 🧠 Inference Options
 
-By default, this project uses [Docker Model Runner] to handle LLM inference locally — no internet connection or external API key is required.
+By default, this project uses [Docker Model Runner] to handle LLM inference locally — no internet
+connection or external API key is required.
 
 If you’d prefer to use OpenAI instead:
 
 1. Create a `secret.openai-api-key` file with your OpenAI API key:
 
-```
-sk-...
-```
+    ```plaintext
+    sk-...
+    ```
 
 2. Restart the project with the OpenAI configuration:
 
-```
-docker compose down -v
-docker compose -f compose.yaml -f compose.openai.yaml up
-```
+    ```sh
+    docker compose down -v
+    docker compose -f compose.yaml -f compose.openai.yaml up
+    ```
 
 # ❓ What Can It Do?
 
-The project lets you explore the [Chinkook database](https://github.com/lerocha/chinook-database) using natural language. This database represents a digital media store with information regarding artists, albums, media tracks, invoices, and customers.
+The project lets you explore the [Chinkook database](https://github.com/lerocha/chinook-database) using
+natural language. This database represents a digital media store with information regarding artists,
+albums, media tracks, invoices, and customers.
 
 The agent will write the SQL for your natural language questions:
-- “Who was the best-selling sales agent in 2010?”
-- “List the top 3 albums by sales.”
-- “How many customers are from Brazil?”
+
++ “Who was the best-selling sales agent in 2010?”
++ “List the top 3 albums by sales.”
++ “How many customers are from Brazil?”
 
 You can **customize the initial question** asked by the agent — just edit the question in `compose.yaml`.
 
-Need to work with a **different dataset?** Simply swap out `Chinook.db` with your own SQLite file and update the mount path in `compose.yaml`.
-
+Need to work with a **different dataset?** Simply swap out `Chinook.db` with your own SQLite file and
+update the mount path in `compose.yaml`.
 
 # 🧱 Project Structure
 
@@ -72,8 +79,6 @@ Need to work with a **different dataset?** Simply swap out `Chinook.db` with you
 | `Dockerfile`   | Builds the container environment.                                         |
 | `agent.py`     | Contains the LangGraph agent and logic for forming and answering queries. |
 | `Chinook.db`   | Example SQLite database — can be replaced with your own.                  |
-
-
 
 # 🔧 Architecture Overview
 
@@ -96,10 +101,9 @@ flowchart TD
     B -->|Response| A
 ```
 
-- The LangGraph-based agent transforms questions into SQL.
-- PostgreSQL is populated from a SQLite dump at runtime.
-- All components are fully containerized for plug-and-play usage.
-
++ The LangGraph-based agent transforms questions into SQL.
++ PostgreSQL is populated from a SQLite dump at runtime.
++ All components are fully containerized for plug-and-play usage.
 
 # 🧹 Cleanup
 
@@ -109,15 +113,17 @@ To stop and remove containers and volumes:
 docker compose down -v
 ```
 
-
 # 📎 Credits
-- [LangGraph]
-- [PostgreSQL]
-- [Docker Compose]
 
++ [LangGraph]
++ [PostgreSQL]
++ [Docker Compose]
 
 [LangGraph]: https://github.com/langchain-ai/langgraph
 [PostgreSQL]: https://postgresql.org
 [Docker Compose]: https://github.com/docker/compose
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Engine]: https://docs.docker.com/engine/
 [Docker Model Runner]: https://docs.docker.com/ai/model-runner/
+[Docker Model Runner requirements]: https://docs.docker.com/ai/model-runner/
+[Docker Offload]: https://www.docker.com/products/docker-offload/

--- a/spring-ai/README.md
+++ b/spring-ai/README.md
@@ -1,6 +1,8 @@
 # 🧠 Spring AI + DuckDuckGo with Model Context Protocol (MCP)
 
-This project demonstrates a **zero-config Spring Boot application** using [Spring AI] and the **Model Context Protocol (MCP)** to answer natural language questions by performing real-time web search via [DuckDuckGo] — all orchestrated with [Docker Compose].
+This project demonstrates a **zero-config Spring Boot application** using [Spring AI] and
+the **Model Context Protocol (MCP)** to answer natural language questions by performing
+real-time web search via [DuckDuckGo] — all orchestrated with [Docker Compose].
 
 > [!Tip]
 > ✨ No configuration needed — run it with a single command.
@@ -12,15 +14,17 @@ This project demonstrates a **zero-config Spring Boot application** using [Sprin
        style="border: 1px solid #ccc; border-radius: 8px;" />
 </p>
 
-
 # 🚀 Getting Started
 
 ### Requirements
 
-+ **[Docker Desktop](https://www.docker.com/products/docker-desktop/) 4.43.0+ or [Docker Engine](https://docs.docker.com/engine/)** installed
-+ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you don't have a GPU, you can alternatively use [**Docker Offload**](https://www.docker.com/products/docker-offload).
-+ If you're using Docker Engine on Linux or Docker Desktop on Windows, ensure that the [Docker Model Runner requirements](https://docs.docker.com/ai/model-runner/) are met (specifically that GPU support is enabled) and the necessary drivers are installed
-+ If you're using Docker Engine on Linux, ensure you have Compose 2.38.1 or later installed
++ **[Docker Desktop] 4.43.0+ or [Docker Engine]** installed.
++ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you
+  don't have a GPU, you can alternatively use **[Docker Offload]**.
++ If you're using [Docker Engine] on Linux or [Docker Desktop] on Windows, ensure that the
+  [Docker Model Runner requirements] are met (specifically that GPU
+  support is enabled) and the necessary drivers are installed.
++ If you're using Docker Engine on Linux, ensure you have [Docker Compose] 2.38.1 or later installed.
 
 ### Run the project
 
@@ -32,35 +36,37 @@ No setup, API keys, or additional configuration required.
 
 # 🧠 Inference Options
 
-By default, this project uses [Docker Model Runner] to handle LLM inference locally — no internet connection or external API key is required.
+By default, this project uses [Docker Model Runner] to handle LLM inference locally — no internet
+connection or external API key is required.
 
 If you’d prefer to use OpenAI instead:
 
 1. Create a `secret.openai-api-key` file with your OpenAI API key:
 
-```
-sk-...
-```
+    ```plaintext
+    sk-...
+    ```
 
 2. Restart the project with the OpenAI configuration:
 
-```
-docker compose down -v
-docker compose -f compose.yaml -f compose.openai.yaml up
-```
+    ```sh
+    docker compose down -v
+    docker compose -f compose.yaml -f compose.openai.yaml up
+    ```
 
 # ❓ What Can It Do?
 
 Ask natural language questions and let Spring AI + DuckDuckGo Search provide intelligent, real-time answers:
 
-- “Does Spring AI support the Model Context Protocol?”
-- “What is the Brave Search API?”
-- “Give me examples of Spring Boot AI integrations.”
++ “Does Spring AI support the Model Context Protocol?”
++ “What is the Brave Search API?”
++ “Give me examples of Spring Boot AI integrations.”
 
 The application uses:
-- A MCP-compatible gateway to route queries to DuckDuckGo Search
-- Spring AI’s LLM client to embed results into answers
-- Auto-configuration via Spring Boot to bind everything
+
++ A MCP-compatible gateway to route queries to DuckDuckGo Search
++ Spring AI’s LLM client to embed results into answers
++ Auto-configuration via Spring Boot to bind everything
 
 To **customize the question** asked to the agent, edit the `QUESTION` environment variable in `compose.yaml`.
 
@@ -91,18 +97,21 @@ flowchart TD
 
 ```
 
-- The application loads a question via the `QUESTION` environment variable.
-- MCP is used as a tool in the LLM pipeline.
-- The response is enriched with real-time DuckDuckGo Search results.
++ The application loads a question via the `QUESTION` environment variable.
++ MCP is used as a tool in the LLM pipeline.
++ The response is enriched with real-time DuckDuckGo Search results.
 
 # 📎 Credits
 
-- [Spring AI]
-- [DuckDuckGo]
-- [Docker Compose]
++ [Spring AI]
++ [DuckDuckGo]
++ [Docker Compose]
 
 [DuckDuckGo]: https://duckduckgo.com
 [Spring AI]: https://github.com/spring-projects/spring-ai
-[Docker Compose]: https://docs.docker.com/compose/
+[Docker Compose]: https://github.com/docker/compose
 [Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Engine]: https://docs.docker.com/engine/
 [Docker Model Runner]: https://docs.docker.com/ai/model-runner/
+[Docker Model Runner requirements]: https://docs.docker.com/ai/model-runner/
+[Docker Offload]: https://www.docker.com/products/docker-offload/

--- a/vercel/README.md
+++ b/vercel/README.md
@@ -1,19 +1,26 @@
 # MCP UI with Vercel AI SDK
 
-Start an MCP UI application that uses the [Vercel AI SDK] to provide a chat interface for local models, provided by the Docker Model Runner, with access to MCPs from the [Docker MCP Catalog].
+Start an MCP UI application that uses the [Vercel AI SDK] to provide a chat interface for local models,
+provided by the [Docker Model Runner], with access to MCPs from the [Docker MCP Catalog].
 
-The application will start up with two models loaded (qwen3 and llama3.2), which both support tool calling.  See the [./compose.yaml](./compose.yaml) file for examples of how to add more models.
+The application will start up with two models loaded (qwen3 and llama3.2), which both support tool
+calling. See the [./compose.yaml](./compose.yaml) file for examples of how to add more models.
 
-The application also starts with a connection to the Docker MCP Gateway, which has been configured to provide access to two MCPs (Brave and Wikipedia).  See the [./compose.yaml](./compose.yaml) file for examples of how to provide access to more MCPs.
+The application also starts with a connection to the Docker MCP Gateway, which has been configured to
+provide access to two MCPs (Brave and Wikipedia).  See the [./compose.yaml](./compose.yaml) file for
+examples of how to provide access to more MCPs.
 
 # Getting Started
 
 ### Requirements
 
-+ **[Docker Desktop](https://www.docker.com/products/docker-desktop/) 4.43.0+ or [Docker Engine](https://docs.docker.com/engine/)** installed
-+ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you don't have a GPU, you can alternatively use [**Docker Offload**](https://www.docker.com/products/docker-offload).
-+ If you're using Docker Engine on Linux or Docker Desktop on Windows, ensure that the [Docker Model Runner requirements](https://docs.docker.com/ai/model-runner/) are met (specifically that GPU support is enabled) and the necessary drivers are installed
-+ If you're using Docker Engine on Linux, ensure you have Compose 2.38.1 or later installed
++ **[Docker Desktop] 4.43.0+ or [Docker Engine]** installed.
++ **A laptop or workstation with a GPU** (e.g., a MacBook) for running open models locally. If you
+  don't have a GPU, you can alternatively use **[Docker Offload]**.
++ If you're using [Docker Engine] on Linux or [Docker Desktop] on Windows, ensure that the
+  [Docker Model Runner requirements] are met (specifically that GPU
+  support is enabled) and the necessary drivers are installed.
++ If you're using Docker Engine on Linux, ensure you have [Docker Compose] 2.38.1 or later installed.
 
 ### Configure MCP secrets
 
@@ -42,7 +49,8 @@ Access the MCP UI at [http://localhost:3000](http://localhost:3000).
 
 # What can it do?
 
-Choose one of the two local models loaded by compose.yaml, and request that it do something with either Brave Search, or the Wikipedia tools.  For example:
+Choose one of the two local models loaded by compose.yaml, and request that it do something with either
+Brave Search, or the Wikipedia tools.  For example:
 
 > do a wikipedia search for articles about Docker and MCP
 
@@ -72,10 +80,16 @@ docker compose down
 
 # Credits
 
-- [Vercel AI SDK]
-- [Docker MCP Toolkit]
-- [Docker MCP Catalog]
++ [Vercel AI SDK]
++ [Docker MCP Toolkit]
++ [Docker MCP Catalog]
 
 [Vercel AI SDK]: https://ai-sdk.dev/docs/introduction
 [Docker MCP Toolkit]: https://docs.docker.com/ai/mcp-catalog-and-toolkit/toolkit/
 [Docker MCP Catalog]: https://hub.docker.com/mcp
+[Docker Compose]: https://github.com/docker/compose
+[Docker Desktop]: https://www.docker.com/products/docker-desktop/
+[Docker Engine]: https://docs.docker.com/engine/
+[Docker Model Runner]: https://docs.docker.com/ai/model-runner/
+[Docker Model Runner requirements]: https://docs.docker.com/ai/model-runner/
+[Docker Offload]: https://www.docker.com/products/docker-offload/


### PR DESCRIPTION
- Use markdownlint-cli2 to lint markdown files
- Add a workflow to trigger on PRs and after pushing, to lint all
  markdown files
- Add a minimal configuration for the linter
- Update all .md files to abide by the linter rules