### PR TITLE
fix(agno): use stdio instead of sse for MCP

### DIFF
--- a/agno/agent/Dockerfile
+++ b/agno/agent/Dockerfile
@@ -1,5 +1,8 @@
 FROM python:3.13-slim
 ENV PYTHONUNBUFFERED=1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    socat \
+    && rm -rf /var/lib/apt/lists/*
 RUN pip install uv
 
 WORKDIR /app

--- a/agno/compose.yaml
+++ b/agno/compose.yaml
@@ -8,7 +8,7 @@ services:
       - "7777:7777"
     environment:
       # point agents at the MCP gateway
-      - MCPGATEWAY_URL=http://mcp-gateway:8811/sse
+      - MCPGATEWAY_URL=mcp-gateway:8811
     volumes:
       # mount the agents file
       - ./agents.yaml:/agents.yaml
@@ -34,7 +34,6 @@ services:
     # use docker API socket to start MCP servers
     use_api_socket: true
     command:
-      - --transport=sse
       # securely embed secrets into the gateway
       - --secrets=/run/secrets/mcp_secret
       # add any MCP servers you want to use


### PR DESCRIPTION
It seems Agno has some issues when using SSE. Switching the MCP client
to use STDIO workarounds the problem.

Fixes #78
