### PR TITLE
fix: improve DuckDuckGo MCP gateway reliability and clarify platform …

### DIFF
--- a/adk/compose.yaml
+++ b/adk/compose.yaml
@@ -1,28 +1,35 @@
+version: "3.8"
+
 services:
   adk:
+    platform: linux/amd64
     build:
       context: .
     ports:
       # expose port for web interface
       - "8080:8080"
     environment:
-      # point adk at the MCP gateway
+      # point ADK at the MCP gateway
       - MCPGATEWAY_ENDPOINT=http://mcp-gateway:8811/sse
     depends_on:
       - mcp-gateway
     models:
-      gemma3 :
+      gemma3:
         endpoint_var: MODEL_RUNNER_URL
         model_var: MODEL_RUNNER_MODEL
 
   mcp-gateway:
     # mcp-gateway secures your MCP servers
     image: docker/mcp-gateway:latest
+    platform: linux/amd64
     use_api_socket: true
+    volumes:
+      # allow gateway to spin up MCP servers via Docker
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      # mount your custom MCP configuration
+      - ./mcp-config.yaml:/app/config.yaml:ro
     command:
       - --transport=sse
-      # add any MCP servers you want to use
-      - --servers=duckduckgo
 
 models:
   gemma3:

--- a/adk/mcp-config.yaml
+++ b/adk/mcp-config.yaml
@@ -1,0 +1,19 @@
+# mcp-config.yaml
+hostname: "0.0.0.0"
+port: 8811
+
+servers:
+  duckduckgo:
+    # explicitly tell the gateway how to run the MCP server
+    command: docker
+    args:
+      - run
+      - --rm
+      - -i
+      - --init
+      - --security-opt=no-new-privileges
+      - --cpus=1
+      - --memory=2Gb
+      - -e
+      - DDG_USER_AGENT="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36"
+      - mcp/duckduckgo:latest


### PR DESCRIPTION
fix: improve DuckDuckGo MCP gateway reliability and clarify platform usage

- Added mcp-config.yaml with explicit DDG_USER_AGENT to help bypass DuckDuckGo bot detection.
- Updated compose.yaml to mount the new MCP config and explicitly set platform: linux/amd64 for all services.
- Specifying the platform ensures consistent builds across different host architectures (e.g., Apple Silicon).
- These changes make web search more reliable for all users and reduce bot detection issues.