### PR TITLE
fix(agno): restore MCP functionality

### DIFF
--- a/agno/agent/playground.py
+++ b/agno/agent/playground.py
@@ -79,8 +79,10 @@ async def create_mcp_tools(tools_list: list[str], entity_type: str) -> list[Tool
     transport: str = ""
     if gateway_url.startswith("http://") or gateway_url.startswith("https://"):
         url = gateway_url
-        transport = "sse"
-        print(f"DEBUG: {entity_type} connecting to MCP gateway via SSE {url}")
+        transport = "streamable-http"
+        print(
+            f"DEBUG: {entity_type} connecting to MCP gateway via streamable-http {url}"
+        )
     else:
         # Assume it's a TCP endpoint
         tcp_endpoint = gateway_url

--- a/agno/compose.yaml
+++ b/agno/compose.yaml
@@ -9,6 +9,8 @@ services:
     environment:
       # point agents at the MCP gateway
       - MCPGATEWAY_URL=http://mcp-gateway:8811
+    depends_on:
+      - mcp-gateway
     volumes:
       # mount the agents file
       - ./agents.yaml:/agents.yaml

--- a/agno/compose.yaml
+++ b/agno/compose.yaml
@@ -8,7 +8,7 @@ services:
       - "7777:7777"
     environment:
       # point agents at the MCP gateway
-      - MCPGATEWAY_URL=mcp-gateway:8811
+      - MCPGATEWAY_URL=http://mcp-gateway:8811
     volumes:
       # mount the agents file
       - ./agents.yaml:/agents.yaml
@@ -34,6 +34,7 @@ services:
     # use docker API socket to start MCP servers
     use_api_socket: true
     command:
+      - --transport=streaming
       # securely embed secrets into the gateway
       - --secrets=/run/secrets/mcp_secret
       # add any MCP servers you want to use


### PR DESCRIPTION
Latest mcp-gateway no longer supports stdio over TCP. Since SSE doesn't
seem to work on agno either, use streaming-http instead.
