### PR TITLE
chore: pin litellm versions

### DIFF
--- a/.github/workflows/a2a.yaml
+++ b/.github/workflows/a2a.yaml
@@ -19,6 +19,8 @@ jobs:
   check:
     name: Format & Type Check
     runs-on: ubuntu-latest
+    env:
+      UV_PYTHON: "3.13"
 
     defaults:
       run:
@@ -27,6 +29,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
 
       - name: Install uv
         run: |

--- a/.github/workflows/adk-cerebras.yaml
+++ b/.github/workflows/adk-cerebras.yaml
@@ -19,6 +19,8 @@ jobs:
   check:
     name: Format & Type Check
     runs-on: ubuntu-latest
+    env:
+      UV_PYTHON: "3.13"
 
     defaults:
       run:
@@ -27,6 +29,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
 
       - name: Install uv
         run: |

--- a/.github/workflows/adk.yaml
+++ b/.github/workflows/adk.yaml
@@ -19,6 +19,8 @@ jobs:
   check:
     name: Format & Type Check
     runs-on: ubuntu-latest
+    env:
+      UV_PYTHON: "3.13"
 
     defaults:
       run:
@@ -27,6 +29,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
 
       - name: Install uv
         run: |

--- a/a2a/Dockerfile
+++ b/a2a/Dockerfile
@@ -2,14 +2,15 @@
 FROM python:3.13-slim AS base
 
 ENV PYTHONUNBUFFERED=1
+ENV UV_PROJECT_ENVIRONMENT=/app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 RUN pip install uv
 
 WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy \
-    uv pip install --system . && \
-    rm -fr build dist *.egg-info
+    uv sync --locked --no-dev --no-install-project
 COPY main.py src ./
 RUN python -m compileall -q .
 

--- a/a2a/pyproject.toml
+++ b/a2a/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "click>=8.2.1",
     "google-adk>=1.4.2",
     "google-genai>=1.21.1",
-    "litellm>=1.73.0",
+    "litellm==1.73.0",
     "mcp>=1.9.4",
     "openai>=1.88.0",
     "pydantic>=2.11.7",

--- a/a2a/uv.lock
+++ b/a2a/uv.lock
@@ -34,7 +34,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.2.1" },
     { name = "google-adk", specifier = ">=1.4.2" },
     { name = "google-genai", specifier = ">=1.21.1" },
-    { name = "litellm", specifier = ">=1.73.0" },
+    { name = "litellm", specifier = "==1.73.0" },
     { name = "mcp", specifier = ">=1.9.4" },
     { name = "openai", specifier = ">=1.88.0" },
     { name = "pydantic", specifier = ">=2.11.7" },

--- a/adk-cerebras/pyproject.toml
+++ b/adk-cerebras/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "google-adk>=1.5.0",
-    "litellm>=1.73.6",
+    "litellm==1.73.6",
 ]
 
 [dependency-groups]

--- a/adk-cerebras/uv.lock
+++ b/adk-cerebras/uv.lock
@@ -20,7 +20,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "google-adk", specifier = ">=1.5.0" },
-    { name = "litellm", specifier = ">=1.73.6" },
+    { name = "litellm", specifier = "==1.73.6" },
 ]
 
 [package.metadata.requires-dev]

--- a/adk-sock-shop/Dockerfile
+++ b/adk-sock-shop/Dockerfile
@@ -1,6 +1,8 @@
-# Use Python 3.11 slim image as base
+# Use Python 3.13 slim image as base
 FROM python:3.13-slim
 ENV PYTHONUNBUFFERED=1
+ENV UV_PROJECT_ENVIRONMENT=/app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
 RUN pip install uv
 
@@ -8,7 +10,8 @@ WORKDIR /app
 # Install system dependencies
 COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
-    UV_COMPILE_BYTECODE=1 uv pip install --system .
+    UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy \
+    uv sync --locked --no-dev --no-install-project
 # Copy application code
 COPY agents/ ./agents/
 RUN python -m compileall -q .

--- a/adk-sock-shop/pyproject.toml
+++ b/adk-sock-shop/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "google-adk>=1.5.0",
-    "litellm>=1.73.2",
+    "litellm==1.73.2",
     "streamlit>=1.31.0",
     "requests>=2.31.0",
     "fastapi>=0.100.0",

--- a/adk-sock-shop/uv.lock
+++ b/adk-sock-shop/uv.lock
@@ -25,7 +25,7 @@ dev = [
 requires-dist = [
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "google-adk", specifier = ">=1.5.0" },
-    { name = "litellm", specifier = ">=1.73.2" },
+    { name = "litellm", specifier = "==1.73.2" },
     { name = "requests", specifier = ">=2.31.0" },
     { name = "sseclient-py", specifier = ">=1.8.0" },
     { name = "streamlit", specifier = ">=1.31.0" },

--- a/adk/Dockerfile
+++ b/adk/Dockerfile
@@ -1,6 +1,8 @@
-# Use Python 3.11 slim image as base
+# Use Python 3.13 slim image as base
 FROM python:3.13-slim
 ENV PYTHONUNBUFFERED=1
+ENV UV_PROJECT_ENVIRONMENT=/app/.venv
+ENV PATH="/app/.venv/bin:$PATH"
 
 RUN pip install uv
 
@@ -9,8 +11,7 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 RUN --mount=type=cache,target=/root/.cache/uv \
     UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy \
-    uv pip install --system . && \
-    rm -fr build dist *.egg-info
+    uv sync --locked --no-dev --no-install-project
 # Copy application code
 COPY agents/ ./agents/
 RUN python -m compileall -q .

--- a/adk/pyproject.toml
+++ b/adk/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "google-adk>=1.5.0",
-    "litellm>=1.73.2",
+    "litellm==1.73.2",
 ]
 
 [dependency-groups]

--- a/adk/uv.lock
+++ b/adk/uv.lock
@@ -20,7 +20,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "google-adk", specifier = ">=1.5.0" },
-    { name = "litellm", specifier = ">=1.73.2" },
+    { name = "litellm", specifier = "==1.73.2" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary
- pin `litellm` to the versions currently resolved in each project
- align `uv.lock` metadata with the pinned dependency constraints

## Verification
- `uv lock --check` in `a2a`
- `uv lock --check` in `adk`
- `uv lock --check` in `adk-sock-shop`
- `uv lock --check` in `adk-cerebras`