### PR TITLE
Fix marketing copy structured output schema

### DIFF
--- a/crew-ai/src/marketing_posts/crew.py
+++ b/crew-ai/src/marketing_posts/crew.py
@@ -46,6 +46,13 @@ class Copy(BaseModel):
     body: str = Field(..., description="Body of the copy")
 
 
+class Copies(BaseModel):
+    """Marketing copy collection model"""
+
+    title: str = Field(..., description="Title for the set of marketing copies")
+    copies: List[Copy] = Field(..., description="List of marketing copies")
+
+
 @CrewBase
 class MarketingPostsCrew:
     """MarketingPosts crew"""
@@ -112,7 +119,7 @@ class MarketingPostsCrew:
             config=self.tasks_config["copy_creation_task"],  # type: ignore
             agent=self.creative_content_creator(),
             context=[self.marketing_strategy_task(), self.campaign_idea_task()],
-            output_json=Copy,
+            output_json=Copies,
         )
 
     @crew


### PR DESCRIPTION
## Summary

Fixed an output validation issue in the CrewAI marketing posts example.

When running the example, the pipeline consistently failed on the final step with the `Creative Content Creator` agent and raised a Pydantic `ValidationError`.

The final task generates multiple pieces of marketing copy, but the configured output schema only accepts a single `Copy` object.

## Fix

Added a `Copies` wrapper model and updated `copy_creation_task` to use that schema instead, so the final output can include a list of copy text items.

The pipeline consistently completes, and I have not seen the validation error again.